### PR TITLE
Add utility functions

### DIFF
--- a/src/utils/__tests__/composeProps-test.js
+++ b/src/utils/__tests__/composeProps-test.js
@@ -1,0 +1,23 @@
+import { expect } from 'chai'
+import composeProps from '../composeProps'
+
+describe('utils/composeProps', () => {
+  it('copies values into a target', () => {
+    const target = {}
+    const values = { foo: 'foo' }
+    composeProps(target, values)
+    expect(target).to.eql(values)
+  })
+
+  it('returnes the composed target object', () => {
+    const target = {}
+    const values = { foo: 'foo' }
+    expect(composeProps(target, values)).to.eql(values)
+  })
+
+  it('combines "className" values', () => {
+    const target = { className: 'foo' }
+    const values = { className: 'bar' }
+    expect(composeProps(target, values)).to.eql({ className: 'foo bar' })
+  })
+})

--- a/src/utils/__tests__/keyMirror-test.js
+++ b/src/utils/__tests__/keyMirror-test.js
@@ -1,0 +1,11 @@
+import { expect } from 'chai'
+import keyMirror from '../keyMirror'
+
+describe('utils/keyMirror', () => {
+  it('converts an array into an object with mirrored key/values', () => {
+    expect(keyMirror(['one', 'two'])).to.eql({
+      one: 'one',
+      two: 'two',
+    })
+  })
+})

--- a/src/utils/__tests__/parseArgs-test.js
+++ b/src/utils/__tests__/parseArgs-test.js
@@ -1,0 +1,42 @@
+import { expect } from 'chai'
+import parseArgs from '../parseArgs'
+
+describe('utils/parseArgs', () => {
+  const component = () => null
+  const props = { className: 'foo' }
+
+  it('returns an array', () => {
+    expect(parseArgs()).to.be.an('array')
+  })
+
+  context('when value is null', () => {
+    it('returns default component and default props', () => {
+      const args = parseArgs(null, component, props)
+      expect(args).to.eql([component, props])
+    })
+  })
+
+  context('when value is a function', () => {
+    it('returns value and default props', () => {
+      const value = () => null
+      const args = parseArgs(value, component, props)
+      expect(args).to.eql([value, props])
+    })
+  })
+
+  context('when value is an object', () => {
+    it('returns default component and composed props', () => {
+      const value = { className: 'bar', id: 'bar' }
+      const args = parseArgs(value, component, props)
+      expect(args).to.eql([component, { className: 'foo bar', id: 'bar' }])
+    })
+  })
+
+  context('when value is a string', () => {
+    it('returns default component, default props, and value as child', () => {
+      const value = 'Hello World!'
+      const args = parseArgs(value, component, props)
+      expect(args).to.eql([component, props, value])
+    })
+  })
+})

--- a/src/utils/__tests__/randomId-test.js
+++ b/src/utils/__tests__/randomId-test.js
@@ -1,0 +1,13 @@
+import { expect } from 'chai'
+import randomId from '../randomId'
+
+describe('utils/randomId', () => {
+  it('creates a random string id', () => {
+    expect(randomId()).to.be.a('string')
+    expect(randomId()).to.not.equal(randomId())
+  })
+
+  it('uses a custom prefix', () => {
+    expect(randomId('prefix').substr(0, 6)).to.equal('prefix')
+  })
+})

--- a/src/utils/composeProps.js
+++ b/src/utils/composeProps.js
@@ -1,0 +1,38 @@
+import classNames from 'classnames'
+
+/**
+ * Merges react component props, using regular
+ * shallow merging for everything except the
+ * className prop, which gets concatenated.
+ *
+ * @param {object} target The target object.
+ * @param {...object} items The source objects.
+ * @return {object}
+ */
+export default (target, ...items) => {
+  if (!items.length) {
+    return target
+  }
+
+  const classnames = []
+
+  if (target.className) {
+    classnames.push(target.className)
+  }
+
+  items.reduce((acc, props) => {
+    if (!props) {
+      return acc
+    }
+    if (props.className) {
+      classnames.push(props.className)
+    }
+    return Object.assign(acc, props)
+  }, target)
+
+  if (classnames.length > 1) {
+    target.className = classNames(...classnames) // eslint-disable-line no-param-reassign
+  }
+
+  return target
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,4 @@
+export { default as randomId } from './randomId'
+export { default as parseArgs } from './parseArgs'
+export { default as composeProps } from './composeProps'
+export { default as keyMirror } from './keyMirror'

--- a/src/utils/keyMirror.js
+++ b/src/utils/keyMirror.js
@@ -1,0 +1,13 @@
+/**
+ * Converts an array to an object where
+ * keys mirror their values.
+ *
+ * @param {array} keys The key/values to use.
+ * @return {object}
+ */
+export default keys => (
+  keys.reduce((acc, key) => {
+    acc[key] = key // eslint-disable-line no-param-reassign
+    return acc
+  }, {})
+)

--- a/src/utils/parseArgs.js
+++ b/src/utils/parseArgs.js
@@ -1,0 +1,30 @@
+import compose from './composeProps'
+
+/**
+ * Parses a value to extract an arguments array
+ * suitable for calling React.createElement()
+ *
+ * @param {any} value The value to parse
+ * @param {function} [component] Default component
+ * @param {object} [props] Default props
+ * @return {array}
+ */
+export default (
+  value,
+  component,
+  props,
+) => {
+  const args = []
+
+  if (typeof value === 'function') {
+    args.push(value, props)
+  } else if (typeof value === 'object') {
+    args.push(component, props ? compose(props, value) : value)
+  } else if (value) {
+    args.push(component, props, value)
+  } else {
+    args.push(component, props)
+  }
+
+  return args
+}

--- a/src/utils/randomId.js
+++ b/src/utils/randomId.js
@@ -1,0 +1,18 @@
+/**
+ * Generates a random string.
+ *
+ * @return {string}
+ */
+const randomStr = () => (
+  (Math.random() + 1).toString(36).substring(2, 7)
+)
+
+/**
+ * Generates a random alphanumeric ID.
+ *
+ * @param {string} [prefix] An optional prefix.
+ * @return {string}
+ */
+export default prefix => (
+  `${prefix || randomStr()}-${Math.floor(Math.random() * 0xFFFF)}`.replace(/[^a-z0-9-_]/gi)
+)


### PR DESCRIPTION
- [x] requires https://github.com/rentpath/react-ui/pull/5

Adds the following utility functions:
- `keyMirror` - useful for creating mock themes.
- `randomId` - generates a random ID, will be used for generating ID's for inputs/labels
- `composeProps` - currently just handles concatenating of `className` props.
- `parseArgs` - Takes a value, and extracts arguments used for a call to `React.createElement()`.  useful in scenarios where a component defines a prop that is used to customize a child component.  For example, a `label` prop (on an `Input` component) might be a string, object, or function.  This utility function will evaluate the prop, and give you args to render the _customized_ label input.