### PR TITLE
Support local css for react-flexbox-grid

### DIFF
--- a/packages/react-ui-core/package.json
+++ b/packages/react-ui-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rentpath/react-ui-core",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {

--- a/packages/react-ui-core/src/Layout/Grid.js
+++ b/packages/react-ui-core/src/Layout/Grid.js
@@ -8,20 +8,23 @@ import {
 
 import cn from 'classnames'
 
-class Col extends PureComponent {
-  // NOTE: add /fleboxgrid/ to css loader webpack config before use
-  // https://github.com/roylee0704/react-flexbox-grid#minimal-configuration
+export const localizeCss = css => {
+  Grid.localCss = css
+  Row.localCss = css
+  FlexCol.localCss = css
+}
 
+class Col extends PureComponent {
   static propTypes = {
     className: PropTypes.string,
     // less than 768px (phones)
-    xs: PropTypes.number,
+    xs: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
     // min width of 768px (tablets)
-    sm: PropTypes.number,
+    sm: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
     // min width of 1024px (laptops/desktops)
-    md: PropTypes.number,
+    md: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
     // min width of 1200px (large monitors)
-    lg: PropTypes.number,
+    lg: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
   }
 
   get mappedProps() {

--- a/packages/react-ui-core/src/Layout/index.js
+++ b/packages/react-ui-core/src/Layout/index.js
@@ -2,4 +2,5 @@ export {
   default as Grid,
   Row,
   Col,
+  localizeCss,
 } from './Grid'

--- a/packages/react-ui-core/src/index.js
+++ b/packages/react-ui-core/src/index.js
@@ -2,6 +2,7 @@ export {
   Grid,
   Row,
   Col,
+  localizeCss,
 } from './Layout'
 
 export {

--- a/packages/react-ui-core/yarn.lock
+++ b/packages/react-ui-core/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+"@rentpath/react-ui-utils@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@rentpath/react-ui-utils/-/react-ui-utils-0.0.1.tgz#e9d5ce96308125048bb0c48e06140bf64419d007"
+  dependencies:
+    classnames "^2.2.5"
+
 abab@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"

--- a/stories/examples/Grid.js
+++ b/stories/examples/Grid.js
@@ -1,8 +1,15 @@
-import "react-ui-core/node_modules/flexboxgrid/dist/flexboxgrid.css"
-import { Grid, Row, Col } from "react-ui-core/node_modules/react-flexbox-grid"
+import styles from "react-ui-core/node_modules/flexboxgrid/dist/flexboxgrid.css"
+import {
+  localizeCss as configureStylesForGrid,
+  Grid,
+  Row,
+  Col
+} from "react-ui-core/src"
 import React from "react"
 import cn from "classnames"
 import { GridTheme as theme } from "../theme"
+
+configureStylesForGrid(styles)
 
 export default (
   <Grid fluid>
@@ -25,9 +32,6 @@ export default (
       sm = min width of 768px (tablets portait and landscape, ipad) <br />
       md = min width of 1024px (laptops/desktops)<br />
       lg = min width of 1200px (large monitors) <br />
-      <br /> OR  <br /> <br />
-      small = less than 768px <br />
-      large = more than 768px
     </code>
     <h2>Center</h2>
     <Row className={theme.row} center="xs">

--- a/stories/examples/ResponsiveTemplate.js
+++ b/stories/examples/ResponsiveTemplate.js
@@ -1,13 +1,22 @@
-import "react-ui-core/node_modules/flexboxgrid/dist/flexboxgrid.css"
-import { Grid, Row, Col } from "react-ui-core/src"
+import styles from "react-ui-core/node_modules/flexboxgrid/dist/flexboxgrid.css"
+import {
+  localizeCss as configureStylesForGrid,
+  Grid,
+  Row,
+  Col
+} from "react-ui-core/src"
+
 import React from "react"
 import cn from "classnames"
 import { ResponsiveTheme as theme } from "../theme"
+
+configureStylesForGrid(styles)
 
 // xs = phone
 // sm = tablet
 // md = desktop
 // lg = large monitors
+
 const result = (
   <div className={theme.result}>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam in feugiat


### PR DESCRIPTION
attempt number 2 to get rentjs-webpack playing nicely with localized styles

solves https://github.com/roylee0704/react-flexbox-grid/issues/80

 [bug](https://www.pivotaltracker.com/story/show/149098767)