### PR TITLE
Pass mapbox-gl library to children via React context

### DIFF
--- a/packages/react-ui-map/package.json
+++ b/packages/react-ui-map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rentpath/react-ui-map",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {

--- a/packages/react-ui-map/src/Mapbox/Mapbox.js
+++ b/packages/react-ui-map/src/Mapbox/Mapbox.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
-import mapboxgl from 'mapbox-gl/dist/mapbox-gl'
+import MapboxGL from 'mapbox-gl/dist/mapbox-gl'
 
 export default class Mapbox extends PureComponent {
   static propTypes = {
@@ -22,6 +22,7 @@ export default class Mapbox extends PureComponent {
 
   static childContextTypes = {
     map: PropTypes.object,
+    MapboxGL: PropTypes.object,
   }
 
   static defaultProps = {
@@ -31,7 +32,6 @@ export default class Mapbox extends PureComponent {
 
   constructor(props, context) {
     super(props, context)
-    mapboxgl.accessToken = props.token
 
     this.state = {
       map: null,
@@ -41,20 +41,12 @@ export default class Mapbox extends PureComponent {
   getChildContext() {
     return {
       map: this.state.map,
+      MapboxGL,
     }
   }
 
   componentDidMount() {
-    const opts = {
-      container: this.container,
-      style: this.props.style,
-      zoom: this.props.zoom,
-      theme: this.props.theme,
-    }
-
-    if (this.props.center) opts.center = this.props.center
-
-    const map = new mapboxgl.Map(opts)
+    const map = this.setupMapbox()
     map.on('load', () => {
       this.setState({ map })
     })
@@ -77,6 +69,18 @@ export default class Mapbox extends PureComponent {
   shouldComponentUpdate(nextProps, nextState) {
     return (nextProps.children !== this.props.children ||
       nextState.map !== this.state.map)
+  }
+
+  setupMapbox() {
+    MapboxGL.accessToken = this.props.token
+    const { center, style, zoom, theme } = this.props
+    return new MapboxGL.Map({
+      container: this.container,
+      style,
+      zoom,
+      theme,
+      ...(center ? { center } : {}),
+    })
   }
 
   render() {

--- a/packages/react-ui-map/src/Mapbox/__tests__/Mapbox-test.js
+++ b/packages/react-ui-map/src/Mapbox/__tests__/Mapbox-test.js
@@ -1,0 +1,41 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import Mapbox from '../Mapbox'
+
+jest.mock('mapbox-gl/dist/mapbox-gl', () => ({
+  Map: () => ({
+    on: (_, callback) => callback(this),
+    isMock: true,
+    accessToken: null,
+  }),
+}))
+
+describe('<Mapbox />', () => {
+  it('renders a map container div', () => {
+    const props = {
+      className: 'testing',
+    }
+    const wrapper = mount(<Mapbox {...props} />)
+    expect(wrapper.find('.testing').length).toBe(1)
+  })
+
+  it('sets the map state', () => {
+    const wrapper = mount(<Mapbox />)
+    const map = wrapper.state().map
+    expect(map.isMock).toBe(true)
+  })
+
+  it('sets the MapboxGL and map context variables', () => {
+    const wrapper = mount(<Mapbox />)
+    const context = wrapper.instance().getChildContext()
+    expect(context.MapboxGL).toBeDefined()
+    expect(context.map.isMock).toBe(true)
+  })
+
+  it('sets the access token', () => {
+    const token = 'testToken1234'
+    const wrapper = mount(<Mapbox token={token} />)
+    const context = wrapper.instance().getChildContext()
+    expect(context.MapboxGL.accessToken).toBe(token)
+  })
+})


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/151062514)

Updating this comment.

I talked to @aribouius earlier. We couldn't get dynamic import to work right now. I've shimmed the `Mapbox` component in `rent-js` to only load this library when on the client side. The `Mapbox` component here will be responsible for loading `mapbox-gl` and passing it down via the `MapboxGL` context variable.

~~Since the component is called `Mapbox` and the library is already setup here, I figured it would be easier to just import the `mapbox-gl` here and have it provide access to the library via React context. Hopefully if we ever need a map again, we won't have to deal with this issue again.~~

~~@tadjohnston, @aribouius -- while this builds without error for both dev/prod mode, it does not seem to create a new chunk in webpack. Actually, it looks like it is creating a new chunk. But SSR is still broken. Any ideas as to what might be going on here? I've tried adding `dynamic-import-node` and `syntax-dynamic-import` to the `.babelrc` in `rent-js`, but still nothing.~~