### PR TITLE
fixing bug with center comparison

### DIFF
--- a/packages/react-ui-core/src/Modal/ModalBody.js
+++ b/packages/react-ui-core/src/Modal/ModalBody.js
@@ -7,7 +7,7 @@ export default class ModalBody extends PureComponent {
     styles: PropTypes.object,
     theme: PropTypes.object,
     className: PropTypes.string,
-    CloseButton: PropTypes.node,
+    CloseButton: PropTypes.func,
     onClose: PropTypes.func,
   }
 

--- a/packages/react-ui-map/package.json
+++ b/packages/react-ui-map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rentpath/react-ui-map",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {

--- a/packages/react-ui-map/src/Mapbox/Mapbox.js
+++ b/packages/react-ui-map/src/Mapbox/Mapbox.js
@@ -54,11 +54,10 @@ export default class Mapbox extends PureComponent {
 
   componentWillReceiveProps(nextProps) {
     const { map } = this.state
+    const { center } = this.props
 
-    const { center, flyOnCenterChange } = nextProps
-
-    if (map && center && (center !== this.props.center)) {
-      if (flyOnCenterChange) {
+    if (map && nextProps.center && this.isCenterChange(center, nextProps.center)) {
+      if (nextProps.flyOnCenterChange) {
         map.flyTo(nextProps.center)
       } else {
         map.setCenter(nextProps.center)
@@ -81,6 +80,13 @@ export default class Mapbox extends PureComponent {
       theme,
       ...(center ? { center } : {}),
     })
+  }
+
+  isCenterChange(center, nextCenter) {
+    const { lat, lng } = center || {}
+    const next = nextCenter || {}
+
+    return lat !== next.lat || lng !== next.lng
   }
 
   render() {


### PR DESCRIPTION
No Story

When the center object ins't changed, it's still creating a new object so the equality check here is invalid every time.  In order to alleviate this issue, we're not checking the actual `lat` and `lng` instead.