### PR TITLE
Some changes for RatingBar after first use

### DIFF
--- a/packages/react-ui-core/package.json
+++ b/packages/react-ui-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rentpath/react-ui-core",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {

--- a/packages/react-ui-core/src/Ratings/LinearGradient.js
+++ b/packages/react-ui-core/src/Ratings/LinearGradient.js
@@ -3,9 +3,10 @@ import PropTypes from 'prop-types'
 
 export default class LinearGradient extends Component {
   static propTypes = {
-    id: PropTypes.string,
-    color: PropTypes.string,
-    width: PropTypes.string,
+    id: PropTypes.string.isRequired,
+    fillColor: PropTypes.string.isRequired,
+    backgroundFillColor: PropTypes.string,
+    width: PropTypes.string.isRequired,
   }
 
   static defaultProps = {
@@ -15,17 +16,34 @@ export default class LinearGradient extends Component {
   render() {
     const {
       id,
-      color,
+      fillColor,
+      backgroundFillColor,
       width,
     } = this.props
+
+    let backgroundStopOpacity = 1
+    let effectiveBackgroundFillColor = backgroundFillColor
+
+    if (!effectiveBackgroundFillColor) {
+      effectiveBackgroundFillColor = fillColor
+      backgroundStopOpacity = 0
+    }
 
     return (
       <defs>
         <linearGradient id={id}>
-          <stop offset="0%" stopOpacity="1" stopColor={color} />
-          <stop offset={width} stopOpacity="1" stopColor={color} />
-          <stop offset={width} stopOpacity="0" stopColor={color} />
-          <stop offset="100%" stopOpacity="0" stopColor={color} />
+          <stop offset="0%" stopOpacity="1" stopColor={fillColor} />
+          <stop offset={width} stopOpacity="1" stopColor={fillColor} />
+          <stop
+            offset={width}
+            stopOpacity={backgroundStopOpacity}
+            stopColor={effectiveBackgroundFillColor}
+          />
+          <stop
+            offset="100%"
+            stopOpacity={backgroundStopOpacity}
+            stopColor={effectiveBackgroundFillColor}
+          />
         </linearGradient>
       </defs>
     )

--- a/packages/react-ui-core/src/Ratings/RatingBar.js
+++ b/packages/react-ui-core/src/Ratings/RatingBar.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import themed from 'react-themed'
+
 import classnames from 'classnames'
 import Star from './Star'
 
@@ -10,8 +11,9 @@ import Star from './Star'
 
 export default class RatingBar extends PureComponent {
   static propTypes = {
+    uniqueId: PropTypes.string.isRequired,
     theme: PropTypes.object,
-    color: PropTypes.string,
+    fillColor: PropTypes.string,
     className: PropTypes.string,
     maxScore: PropTypes.number,
     score: PropTypes.number,
@@ -23,14 +25,15 @@ export default class RatingBar extends PureComponent {
     score: 0,
     maxScore: 5,
     RatingItem: Star,
+    fillColor: 'black',
   }
 
   get ratingItems() {
     const {
+      uniqueId,
       maxScore,
       RatingItem,
       theme,
-      color,
       ...props
     } = this.props
 
@@ -41,10 +44,10 @@ export default class RatingBar extends PureComponent {
           classnames(
             theme.RatingBar_Item,
             theme[`RatingBar_Item-${index}`],
-            color && theme[`RatingBar_Item-${color}`]
+            this.props.fillColor && theme[`RatingBar_Item-${this.props.fillColor}`]
           )
         }
-        id={`rating-item-${index}`}
+        uniqueId={`${uniqueId}-rating-item-${index}`}
         width={`${this.fillWidth(index)}%`}
         {...props}
       />

--- a/packages/react-ui-core/src/Ratings/Star.js
+++ b/packages/react-ui-core/src/Ratings/Star.js
@@ -4,8 +4,9 @@ import LinearGradient from './LinearGradient'
 
 export default class Star extends Component {
   static propTypes = {
-    id: PropTypes.string.isRequired,
-    color: PropTypes.string,
+    uniqueId: PropTypes.string.isRequired,
+    fillColor: PropTypes.string.isRequired,
+    backgroundFillColor: PropTypes.string,
     width: PropTypes.string,
     className: PropTypes.string,
   }
@@ -16,15 +17,16 @@ export default class Star extends Component {
 
   render() {
     const {
-      id,
-      color,
+      uniqueId,
+      fillColor,
+      backgroundFillColor,
       width,
       className,
       ...props
     } = this.props
 
     return (
-      <div {...props}>
+      <div className={className} {...props}>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="50"
@@ -32,12 +34,13 @@ export default class Star extends Component {
           viewBox="0 0 51 48"
         >
           <LinearGradient
-            id={id}
+            id={uniqueId}
             width={width}
-            color={color}
+            fillColor={fillColor}
+            backgroundFillColor={backgroundFillColor}
           />
           <path
-            fill={`url(#${id})`}
+            fill={`url(#${uniqueId})`}
             stroke="#000"
             strokeWidth="3"
             d="m25,1 6,17h18l-14,11 5,17-15-10-15,10 5-17-14-11h18z"

--- a/packages/react-ui-core/src/Ratings/__tests__/RatingBar-test.js
+++ b/packages/react-ui-core/src/Ratings/__tests__/RatingBar-test.js
@@ -7,30 +7,40 @@ const RatingBar = ThemedRatingBar.WrappedComponent
 
 describe('RatingBar', () => {
   it('has a default maxScore', () => {
-    const wrapper = mount(<RatingBar />)
+    const wrapper = mount(<RatingBar uniqueId="foo" />)
     expect(wrapper.find('svg').length).toBe(5)
   })
 
   it('renders empty Ratings when rating is not provided', () => {
-    const wrapper = mount(<RatingBar maxScore={5} />)
+    const wrapper = mount(<RatingBar uniqueId="foo" maxScore={5} />)
     expect(wrapper.find('svg').length).toBe(5)
   })
 
   describe('classNames', () => {
     it('renders a "blue" className when color blue is passed', () => {
-      const wrapper = mount(<RatingBar maxScore={1} theme={theme} color="blue" />)
-      expect(wrapper.find('.RatingBar_Item-blue').length).toBe(1)
+      const wrapper = mount(<RatingBar
+        uniqueId="foo"
+        maxScore={1}
+        theme={theme}
+        fillColor="blue"
+      />)
+      expect(wrapper.find('.RatingBar_Item-blue').length).toBe(2)
     })
 
     it('does not render a "red" className when color does not exist in theme', () => {
-      const wrapper = mount(<RatingBar maxScore={1} theme={theme} color="red" />)
+      const wrapper = mount(<RatingBar
+        uniqueId="foo"
+        maxScore={1}
+        theme={theme}
+        fillColor="red"
+      />)
       expect(wrapper.find('.RatingBar_Item-red').length).toBe(0)
     })
   })
 
   describe('ratings', () => {
     it('fills 1 of 5 rating items', () => {
-      const wrapper = mount(<RatingBar maxScore={5} score={1} />)
+      const wrapper = mount(<RatingBar uniqueId="foo" maxScore={5} score={1} />)
       const gradient = wrapper.find('LinearGradient')
       expect(gradient.at(0).prop('width')).toBe('100%')
       expect(gradient.at(1).prop('width')).toBe('0%')
@@ -40,7 +50,7 @@ describe('RatingBar', () => {
     })
 
     it('fills 3.5 of 5 rating items', () => {
-      const wrapper = mount(<RatingBar maxScore={5} score={3.5} />)
+      const wrapper = mount(<RatingBar uniqueId="foo" maxScore={5} score={3.5} />)
       const gradient = wrapper.find('LinearGradient')
       expect(gradient.at(0).prop('width')).toBe('100%')
       expect(gradient.at(1).prop('width')).toBe('100%')
@@ -50,7 +60,7 @@ describe('RatingBar', () => {
     })
 
     it('fills max when total is more than maxScore', () => {
-      const wrapper = mount(<RatingBar maxScore={5} score={10} />)
+      const wrapper = mount(<RatingBar uniqueId="foo" maxScore={5} score={10} />)
       const gradient = wrapper.find('LinearGradient')
       expect(gradient.at(0).prop('width')).toBe('100%')
       expect(gradient.at(1).prop('width')).toBe('100%')

--- a/stories/SampleRatingItem/Circle.js
+++ b/stories/SampleRatingItem/Circle.js
@@ -4,8 +4,8 @@ import { LinearGradient } from 'react-ui-core/src'
 
 export default class Circle extends Component {
   static propTypes = {
-    id: PropTypes.string.isRequired,
-    color: PropTypes.string,
+    uniqueId: PropTypes.string.isRequired,
+    fillColor: PropTypes.string,
     width: PropTypes.string,
     className: PropTypes.string,
   }
@@ -17,8 +17,8 @@ export default class Circle extends Component {
 
   render() {
     const {
-      id,
-      color,
+      uniqueId,
+      fillColor,
       width,
       className,
       ...props
@@ -33,15 +33,15 @@ export default class Circle extends Component {
           viewBox="0 0 600 300"
         >
           <LinearGradient
-            id={id}
+            id={uniqueId}
             width={width}
-            color={color}
+            fillColor={fillColor}
           />
           <circle
             cx="250"
             cy="150"
             r="145"
-            fill={`url(#${id})`}
+            fill={`url(#${uniqueId})`}
             stroke="crimson"
             strokeWidth="5"
           />

--- a/stories/SampleRatingItem/Square.js
+++ b/stories/SampleRatingItem/Square.js
@@ -4,8 +4,8 @@ import { LinearGradient } from 'react-ui-core/src'
 
 export default class Square extends Component {
   static propTypes = {
-    id: PropTypes.string.isRequired,
-    color: PropTypes.string,
+    uniqueId: PropTypes.string.isRequired,
+    fillColor: PropTypes.string,
     width: PropTypes.string,
     className: PropTypes.string,
   }
@@ -17,8 +17,8 @@ export default class Square extends Component {
 
   render() {
     const {
-      id,
-      color,
+      uniqueId,
+      fillColor,
       width,
       className,
       ...props
@@ -33,12 +33,12 @@ export default class Square extends Component {
           height="50"
         >
           <LinearGradient
-            id={id}
+            id={uniqueId}
             width={width}
-            color={color}
+            fillColor={fillColor}
           />
           <path
-            fill={`url(#${id})`}
+            fill={`url(#${uniqueId})`}
             stroke="#000"
             strokeWidth="3"
             d="M10,990h980V10H10V990z M71.3,71.3h857.5v857.5H71.3V71.3z"

--- a/stories/examples/Ratings.js
+++ b/stories/examples/Ratings.js
@@ -5,96 +5,117 @@ import { RatingBarTheme } from '../theme'
 
 export const DefaultRatings = (
   <RatingBar
+    uniqueId="DefaultRatings"
     score={2.35}
-    color="royalblue"
+    fillColor="royalblue"
     theme={RatingBarTheme}
   />
 )
 
 export const SquareRatings = (
   <RatingBar
+    uniqueId="SquareRatings"
     RatingItem={Square}
     score={5}
     label="15"
-    color="royalblue"
+    fillColor="royalblue"
     theme={RatingBarTheme}
   />
 )
 
 export const CircleRatings = (
   <RatingBar
+    uniqueId="CircleRatings"
     RatingItem={Circle}
     score={4}
     label="200 Rated"
-    color="royalblue"
+    fillColor="royalblue"
     theme={RatingBarTheme}
   />
 )
 
 export const ThreeRatings = (
   <RatingBar
+    uniqueId="ThreeRatings"
     RatingItem={Square}
     score={3}
     label="27 Awesome"
-    color="royalblue"
+    fillColor="royalblue"
     theme={RatingBarTheme}
   />
 )
 
 export const TwoRatings = (
   <RatingBar
+    uniqueId="TwoRatings"
     RatingItem={Square}
     score={2}
     label="403"
-    color="royalblue"
+    fillColor="royalblue"
     theme={RatingBarTheme}
   />
 )
 
 export const OneRatings = (
   <RatingBar
+    uniqueId="OneRatings"
     RatingItem={Circle}
     score={1}
     label="3333"
-    color="royalblue"
+    fillColor="royalblue"
     theme={RatingBarTheme}
   />
 )
 
 export const ManyRatings = (
   <RatingBar
+    uniqueId="ManyRatings"
     RatingItem={Square}
     maxScore={63}
     score={34}
     label="150"
-    color="royalblue"
+    fillColor="royalblue"
     theme={RatingBarTheme}
   />
 )
 
 export const Partial1 = (
   <RatingBar
+    uniqueId="Partial1"
     score={3.5}
     label="150"
-    color="royalblue"
+    fillColor="royalblue"
     theme={RatingBarTheme}
   />
 )
 
 export const Partial2 = (
   <RatingBar
+    uniqueId="Partial2"
     score={4.4}
     label="150"
-    color="royalblue"
+    fillColor="royalblue"
     theme={RatingBarTheme}
   />
 )
 
 export const Partial3 = (
   <RatingBar
+    uniqueId="Partial3"
     score={0.75}
     label="150"
-    color="royalblue"
+    fillColor="royalblue"
+    theme={RatingBarTheme}
+  />
+)
+
+export const PartialTwoColor = (
+  <RatingBar
+    uniqueId="PartialTwoColor"
+    score={3.5}
+    label="150"
+    fillColor="yellow"
+    backgroundFillColor="royalblue"
     theme={RatingBarTheme}
   />
 )

--- a/stories/examples/index.js
+++ b/stories/examples/index.js
@@ -66,4 +66,5 @@ export {
   Partial1,
   Partial2,
   Partial3,
+  PartialTwoColor,
 } from './Ratings'

--- a/stories/index.js
+++ b/stories/index.js
@@ -32,6 +32,7 @@ import {
   Partial1,
   Partial2,
   Partial3,
+  PartialTwoColor,
 } from './examples'
 
 storiesOf('Button', module)
@@ -87,3 +88,4 @@ storiesOf('Ratings', module)
   .addWithInfo('Partial Rating 1', 'Partial Rating 1', () => Partial1)
   .addWithInfo('Partial Rating 2', 'Partial Rating 2', () => Partial2)
   .addWithInfo('Partial Rating 3', 'Partial Rating 3', () => Partial3)
+  .addWithInfo('Two-color Rating', 'Two-color Rating', () => PartialTwoColor)


### PR DESCRIPTION
[Feature](https://www.pivotaltracker.com/story/show/152405882)

This PR makes some changes to the RatingBar components:

- Changes Star to use passed-in className prop
- Adds new required prop `id` for RatingBar, the ids being generated for rating items were not globally unique. this broke RatingBar when more than one of them was rendered in a page.
- Adds an optional second color for RatingsBar, this enables control over both sides of a partially-filled `RatingItem` (see `Two-color Rating` in Storybook => Ratings)