### PR TITLE
bug if props are updated in counter

### DIFF
--- a/packages/react-ui-core/src/Counter/Counter.js
+++ b/packages/react-ui-core/src/Counter/Counter.js
@@ -44,6 +44,12 @@ export default class Counter extends PureComponent {
     this.decrement = this.decrement.bind(this)
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (this.props.count !== nextProps.count) {
+      this.setState({ count: nextProps.count })
+    }
+  }
+
   get renderLabel() {
     const { theme, label } = this.props
 
@@ -88,6 +94,10 @@ export default class Counter extends PureComponent {
       className,
       decrementOperator,
       incrementOperator,
+      text,
+      step,
+      min,
+      max,
       ...props
     } = this.props
 

--- a/packages/react-ui-core/src/Counter/__tests__/Counter-test.js
+++ b/packages/react-ui-core/src/Counter/__tests__/Counter-test.js
@@ -26,6 +26,25 @@ describe('Counter', () => {
     expect(wrapper.prop('count')).toEqual(0)
   })
 
+  describe('when props are changed after mount', () => {
+    let wrapper
+
+    beforeEach(() => {
+      wrapper = shallow(
+        <Counter
+          theme={theme}
+          count={3}
+        />,
+      )
+    })
+
+    it('updates the state for counter', () => {
+      wrapper.setProps({ count: 10 })
+      expect(wrapper.state('count')).toEqual(10)
+      expect(wrapper.find('[data-tid="counter-text"]').text()).toEqual('10')
+    })
+  })
+
   describe('custom text', () => {
     it('uses the default "count" prop when no texst provided', () => {
       const count = 2


### PR DESCRIPTION
No Story

Addresses bug where if props are updated after componentDidMount
the count will never get updated because state is being used after
mount.  Fix is to update state if count prop is not equal to new count
prop.

Also fixed props spread issue on top level counter node.