### PR TITLE
Sentry error - duplicate click

### DIFF
--- a/packages/react-ui-core/package.json
+++ b/packages/react-ui-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rentpath/react-ui-core",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {

--- a/packages/react-ui-core/src/Counter/Counter.js
+++ b/packages/react-ui-core/src/Counter/Counter.js
@@ -109,6 +109,8 @@ export default class Counter extends PureComponent {
             className
           )}
         {...props}
+        // NOTE: ensure click is noop so handler is only on counter spans
+        onClick={() => {}}
       >
         {label && this.renderLabel}
         <div className={theme.Counter_Controls}>

--- a/packages/react-ui-core/src/Counter/__tests__/Counter-test.js
+++ b/packages/react-ui-core/src/Counter/__tests__/Counter-test.js
@@ -80,6 +80,7 @@ describe('Counter', () => {
 
   describe('onClick', () => {
     it('maintains count between min and max', () => {
+      const onClick = jest.fn()
       const wrapper = mount(
         <Counter
           min={1}
@@ -99,6 +100,23 @@ describe('Counter', () => {
       expect(wrapper.state('count')).toEqual(3)
       incrementer.simulate('click')
       expect(wrapper.state('count')).toEqual(3)
+    })
+
+    it('does not allow clicks to propogate from outer div', () => {
+      const onClick = jest.fn()
+      const wrapper = mount(
+        <Counter
+          min={1}
+          count={1}
+          max={3}
+          theme={theme}
+          className="wrappingDiv"
+          onClick={onClick}
+        />
+      )
+      const outerDiv = wrapper.find('div.wrappingDiv')
+      outerDiv.simulate('click')
+      expect(wrapper.prop('onClick')).not.toBeCalled()
     })
 
     it('calls decrement callback', () => {


### PR DESCRIPTION
# bug

https://sentry.io/rentpath/rent-js/issues/414900919/

https://rentpath.leankit.com/card/586265862

The onClick for div was passing the event where wed prefer to have complete control over the onClick handler for the Counter by limiting it to the incrementer and decrementer buttons.