### PR TITLE
Add closeOnSelect and toggleVisibility props to Menu

### DIFF
--- a/packages/react-ui-core/src/Dropdown/Dropdown.js
+++ b/packages/react-ui-core/src/Dropdown/Dropdown.js
@@ -49,16 +49,23 @@ export default class Dropdown extends Component {
     }
   }
 
-  renderAnchor(anchorField) {
-    return parseArgs(anchorField, AnchorButton)
+  renderAnchor() {
+    const [Anchor, fieldProps] = parseArgs(this.props.anchorField, AnchorButton, {
+      'data-tid': 'dropdown-anchor',
+      visible: this.state.visible,
+      handleDocumentClick: this.handleDocumentClick,
+      toggleVisibilty: this.toggleVisibilty,
+    })
+
+    return <Anchor {...fieldProps} />
   }
 
   renderChildren() {
     const props = { toggleVisibilty: this.toggleVisibilty }
     const children = React.Children.toArray(this.props.children)
-    return React.Children.map(children, child =>
-      (typeof child.type === 'function' ? cloneElement(child, props) : child)
-    )
+    return React.Children.map(children, child => (
+      typeof child.type === 'function' ? cloneElement(child, props) : child
+    ))
   }
 
   render() {
@@ -71,8 +78,6 @@ export default class Dropdown extends Component {
       ...props
     } = this.props
 
-    const [Anchor, fieldProps] = this.renderAnchor(anchorField)
-    const dropDownVisible = this.state.visible
     return (
       <div
         ref={ref => { this.dropdown = ref }}
@@ -82,18 +87,9 @@ export default class Dropdown extends Component {
         )}
         {...props}
       >
-        <Anchor
-          data-tid="dropdown-anchor"
-          {...props}
-          {...fieldProps}
-          visible={dropDownVisible}
-          handleDocumentClick={this.handleDocumentClick}
-          toggleVisibilty={this.toggleVisibilty}
-        />
-        {dropDownVisible &&
-          <Card
-            data-tid="dropdown-body"
-          >
+        {this.renderAnchor()}
+        {this.state.visible &&
+          <Card data-tid="dropdown-body">
             {this.renderChildren()}
           </Card>
         }

--- a/packages/react-ui-core/src/Dropdown/Dropdown.js
+++ b/packages/react-ui-core/src/Dropdown/Dropdown.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, cloneElement } from 'react'
 import PropTypes from 'prop-types'
 import themed from 'react-themed'
 import classnames from 'classnames'
@@ -35,7 +35,7 @@ export default class Dropdown extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (this.props.visible !== nextProps.visible) {
-      this.setState({ visible: this.nextProps.visible })
+      this.setState({ visible: nextProps.visible })
     }
   }
 
@@ -53,6 +53,14 @@ export default class Dropdown extends Component {
     return parseArgs(anchorField, AnchorButton)
   }
 
+  renderChildren() {
+    const props = { toggleVisibilty: this.toggleVisibilty }
+    const children = React.Children.toArray(this.props.children)
+    return React.Children.map(children, child =>
+      (typeof child.type === 'function' ? cloneElement(child, props) : child)
+    )
+  }
+
   render() {
     const {
       theme,
@@ -63,9 +71,8 @@ export default class Dropdown extends Component {
       ...props
     } = this.props
 
-    const [Button, fieldProps] = this.renderAnchor(anchorField)
+    const [Anchor, fieldProps] = this.renderAnchor(anchorField)
     const dropDownVisible = this.state.visible
-
     return (
       <div
         ref={ref => { this.dropdown = ref }}
@@ -75,7 +82,8 @@ export default class Dropdown extends Component {
         )}
         {...props}
       >
-        <Button
+        <Anchor
+          data-tid="dropdown-anchor"
           {...props}
           {...fieldProps}
           visible={dropDownVisible}
@@ -86,7 +94,7 @@ export default class Dropdown extends Component {
           <Card
             data-tid="dropdown-body"
           >
-            {children}
+            {this.renderChildren()}
           </Card>
         }
       </div>

--- a/packages/react-ui-core/src/Dropdown/__tests__/DropDown-test.js
+++ b/packages/react-ui-core/src/Dropdown/__tests__/DropDown-test.js
@@ -2,11 +2,10 @@ import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import { mount, shallow } from 'enzyme'
 import { Field } from '../../Form'
-import Dropdown from '../Dropdown'
+import ThemedDropdown from '../Dropdown'
+import theme from './mocks/theme'
 
-const theme = {
-  Dropdown: 'Dropdown',
-}
+const Dropdown = ThemedDropdown.WrappedComponent
 
 class SampleAnchor extends PureComponent {
   static propTypes = {
@@ -27,11 +26,18 @@ class SampleAnchor extends PureComponent {
   }
 }
 
+const SampleChild = props => <button data-tid="child" onClick={props.toggleVisibilty} />
+
+SampleChild.propTypes = {
+  toggleVisibilty: PropTypes.func,
+}
+
 describe('Dropdown', () => {
   const setup = props => {
     const wrapper = mount(
       <Dropdown theme={theme} {...props}>
         <h1>test</h1>
+        <SampleChild />
       </Dropdown>
     )
     return {
@@ -40,38 +46,49 @@ describe('Dropdown', () => {
   }
 
   it('renders children when visible', () => {
-    const shallowWrapper = shallow(
+    const wrapper = shallow(
       <Dropdown visible>
         <h1>test</h1>
       </Dropdown>
     )
-    expect(shallowWrapper.find('h1').length).toEqual(1)
+    expect(wrapper.find('h1')).toHaveLength(1)
   })
 
   it('does not render children when not visible', () => {
-    const { wrapper } = setup({ visible: false })
-    expect(wrapper.find('h1').length).toEqual(0)
+    const wrapper = shallow(
+      <Dropdown visible={false}>
+        <h1>test</h1>
+      </Dropdown>
+    )
+    expect(wrapper.find('h1')).toHaveLength(0)
   })
 
-  it('passes handleClick to anchorField prop', () => {
-    const { wrapper } = setup({ visible: true })
-    expect(wrapper.find('h1').length).toEqual(1)
+  it('default anchor fires toggleVisibilty on click', () => {
+    const { wrapper } = setup({ visible: false })
+    expect(wrapper.find('h1')).toHaveLength(0)
     wrapper.find('button').simulate('click')
-    expect(wrapper.find('h1').length).toEqual(0)
+    expect(wrapper.find('h1')).toHaveLength(1)
   })
 
   it('passes label to default anchor', () => {
     const text = 'test'
-    const { wrapper } = setup({
-      visible: true,
-      text,
-    })
-
+    const wrapper = mount(
+      <Dropdown visible={false} text={'test'}>
+        <h1>hi</h1>
+      </Dropdown>
+    )
     expect(wrapper.find('button').text()).toEqual(text)
   })
 
-  it('passes uses custom anchor if passed to props', () => {
+  it('uses custom anchor if passed to props', () => {
     const { wrapper } = setup({ visible: true, anchorField: SampleAnchor })
     expect(wrapper.find('label').text()).toEqual('click me')
+  })
+
+  it('passes toggleVisibilty to children', () => {
+    const { wrapper } = setup({ visible: true })
+    expect(wrapper.find('h1')).toHaveLength(1)
+    wrapper.find('[data-tid="child"]').simulate('click')
+    expect(wrapper.find('h1')).toHaveLength(0)
   })
 })

--- a/packages/react-ui-core/src/Dropdown/__tests__/mocks/theme.js
+++ b/packages/react-ui-core/src/Dropdown/__tests__/mocks/theme.js
@@ -1,0 +1,7 @@
+import { keyMirror } from '@rentpath/react-ui-utils'
+
+export default keyMirror([
+  'Dropdown',
+  'Button-visible',
+  'Button',
+])

--- a/packages/react-ui-core/src/Menu/Menu.js
+++ b/packages/react-ui-core/src/Menu/Menu.js
@@ -17,6 +17,8 @@ export default class Menu extends PureComponent {
     theme: PropTypes.object,
     className: PropTypes.string,
     options: PropTypes.node,
+    toggleVisibilty: PropTypes.func,
+    closeOnSelection: PropTypes.bool,
     onSelection: PropTypes.func,
     handleSelectionHover: PropTypes.func,
     optionValueSelector: PropTypes.func,
@@ -32,7 +34,9 @@ export default class Menu extends PureComponent {
   static defaultProps = {
     theme: {},
     handleSelectionHover: () => {},
-    onSelection: () => { },
+    toggleVisibilty: () => {},
+    onSelection: () => {},
+    closeOnSelection: true,
     nodeType: 'div',
     listItem: { nodeType: 'div' },
   }
@@ -90,7 +94,14 @@ export default class Menu extends PureComponent {
   }
 
   handleSelection() {
-    this.props.onSelection(this.getValue())
+    const {
+      toggleVisibilty,
+      closeOnSelection,
+      onSelection,
+    } = this.props
+
+    onSelection(this.getValue())
+    if (closeOnSelection) toggleVisibilty()
   }
 
   highlightOption(index) {
@@ -109,6 +120,8 @@ export default class Menu extends PureComponent {
       handleSelectionHover,
       className,
       onSelection,
+      toggleVisibilty,
+      closeOnSelection,
       ...props
     } = this.props
 

--- a/packages/react-ui-core/src/Menu/Menu.js
+++ b/packages/react-ui-core/src/Menu/Menu.js
@@ -34,8 +34,6 @@ export default class Menu extends PureComponent {
   static defaultProps = {
     theme: {},
     handleSelectionHover: () => {},
-    toggleVisibilty: () => {},
-    onSelection: () => {},
     closeOnSelection: true,
     nodeType: 'div',
     listItem: { nodeType: 'div' },
@@ -100,16 +98,13 @@ export default class Menu extends PureComponent {
       onSelection,
     } = this.props
 
-    onSelection(this.getValue())
-    if (closeOnSelection) toggleVisibilty()
+    if (onSelection) onSelection(this.getValue())
+    if (closeOnSelection && toggleVisibilty) toggleVisibilty()
   }
 
   highlightOption(index) {
     if (index < 0 || index >= this.props.options.length) return
-    this.setState({
-      highlightIndex: index,
-    })
-
+    this.setState({ highlightIndex: index })
     this.props.handleSelectionHover(this.getValue())
   }
 

--- a/stories/core/Dropdown.js
+++ b/stories/core/Dropdown.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 import { action } from '@storybook/addon-actions'
-import { Dropdown, List, Text, Menu } from 'react-ui-core/src'
+import { Dropdown, Text, Menu } from 'react-ui-core/src'
 import DropdownButtonExample from './DropdownButtonExample'
 import DropdownInputExample from './DropdownInputExample'
 import StoryBookTheme from '../theme/Storybook.css'
@@ -14,8 +14,9 @@ export const DefaultDropdown = (
   <Dropdown
     className={StoryBookTheme['Story-padding']}
     anchorField={{ text: <Text>Click Me</Text> }}
+    visible
   >
-    <div><h1>Hi</h1></div>
+    <h1>Hi!</h1>
   </Dropdown>
 )
 
@@ -24,7 +25,7 @@ export const DropdownWithProps = (
     anchorField={inputProps}
     className={StoryBookTheme['Story-padding']}
   >
-    <List items={['foo', 'bar', 'baz']} />
+    <Menu options={['foo', 'bar', 'baz']} />
   </Dropdown>
 )
 
@@ -33,7 +34,7 @@ export const DropdownButtonToggle = (
     className={StoryBookTheme['Story-padding']}
     anchorField={props => (<DropdownInputExample {...props} />)}
   >
-    <List items={['foo', 'bar', 'baz']} />
+    <Menu options={['foo', 'bar', 'baz']} />
   </Dropdown>
 )
 
@@ -49,5 +50,6 @@ export const DropdownWithMenu = (
       options={['Option1', 'Option2', 'Option3']}
       handleSelectionHover={action('hovering')}
     />
+    <h1>hello</h1>
   </Dropdown>
 )

--- a/stories/core/DropdownInputExample.js
+++ b/stories/core/DropdownInputExample.js
@@ -17,7 +17,7 @@ export default class DropdownInputExample extends PureComponent {
     document.removeEventListener('click', this.props.handleDocumentClick)
   }
 
-  handleClick = () => {
+  handleFocus = () => {
     const { toggleVisibilty } = this.props
 
     if (!this.props.visible && toggleVisibilty) toggleVisibilty()
@@ -26,7 +26,7 @@ export default class DropdownInputExample extends PureComponent {
   render() {
     return (
       <Field
-        onClick={this.handleClick}
+        onFocus={this.handleFocus}
         label="Say Hi"
       />
     )

--- a/stories/core/index.js
+++ b/stories/core/index.js
@@ -207,7 +207,7 @@ storiesOf('react-ui-core / Dropdown', module)
   .add('Dropdown', () => DefaultDropdown)
   .add('Dropdown With Anchor Props', () => DropdownWithProps)
   .add('Custom Dropdown Input anchor', () => DropdownButtonToggle)
-  .add('Custom Dropdown With Menu', () => DropdownWithMenu)
+  .add('Custom Dropdown With Menu and multiple children', () => DropdownWithMenu)
 
 storiesOf('react-ui-core / Menu', module)
   .addDecorator((story, context) => withInfo(' Menu')(story)(context))


### PR DESCRIPTION
[story](https://rentpath.leankit.com/card/591017663)

Worked with @yasabere and @mneumark 

Allow Dropdown's children to control visibility through `toggleVisibility` function.
Add `toggleVisibility` and `closeOnSelection`(bool) props to `Menu`
Change `visible: this.nextProps.visible` to `visible: nextProps.visible`