### PR TITLE
Add PriceFilterDropdown to react-ui-ag

### DIFF
--- a/packages/react-ui-ag/src/Filters/DropdownAnchorText.js
+++ b/packages/react-ui-ag/src/Filters/DropdownAnchorText.js
@@ -1,0 +1,23 @@
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+import { Text } from '@rentpath/react-ui-core'
+
+export default class DropdownAnchorText extends PureComponent {
+  static propTypes = {
+    text: PropTypes.string,
+    defaultText: PropTypes.string.isRequired,
+    icon: PropTypes.node,
+  }
+  static defaultProps = {
+    icon: '⌄',
+  }
+
+  render() {
+    const { text, defaultText, icon } = this.props
+
+    return [
+      <Text key="dropdown-anchor-text">{text || defaultText}</Text>,
+      <span key="dropdown-anchor-icon">{icon}</span>,
+    ]
+  }
+}

--- a/packages/react-ui-ag/src/Filters/DropdownFilterCardWrapper.js
+++ b/packages/react-ui-ag/src/Filters/DropdownFilterCardWrapper.js
@@ -1,14 +1,14 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import autobind from 'autobind-decorator'
-import RadioGroupFilterCard from './RadioGroupFilterCard'
 
-export default class RadioGroupDropdownFilterCardWrapper extends PureComponent {
+export default class DropdownFilterCardWrapper extends PureComponent {
   static propTypes = {
     onSelect: PropTypes.func,
     handleValueChange: PropTypes.func,
     applyButton: PropTypes.object,
     cancelButton: PropTypes.object,
+    FilterCard: PropTypes.func.isRequired,
   }
 
   static defaultProps = {
@@ -39,11 +39,12 @@ export default class RadioGroupDropdownFilterCardWrapper extends PureComponent {
       handleValueChange,
       applyButton,
       cancelButton,
+      FilterCard,
       ...safeProps
     } = this.props
 
     return (
-      <RadioGroupFilterCard
+      <FilterCard
         {...safeProps}
         applyButton={{ ...applyButton, onClick: this.handleApplyClick }}
         cancelButton={{ ...cancelButton, onClick: this.handleCancelClick }}

--- a/packages/react-ui-ag/src/Filters/PriceFilterDropdown.js
+++ b/packages/react-ui-ag/src/Filters/PriceFilterDropdown.js
@@ -4,26 +4,15 @@ import themed from 'react-themed'
 import autobind from 'autobind-decorator'
 import classnames from 'classnames'
 import { Dropdown, Text } from '@rentpath/react-ui-core'
-import RadioGroupFilterCard from './RadioGroupFilterCard'
+import PriceFilterCard from './PriceFilterCard'
 import DropdownFilterCardWrapper from './DropdownFilterCardWrapper'
 
-const nodeFuncOrObject = PropTypes.oneOfType([
-  PropTypes.node,
-  PropTypes.func,
-  PropTypes.object,
-])
-
-@themed(['RadioGroupDropdown'])
-export default class RadioGroupDropdown extends Component {
+@themed(['PriceFilterDropdown'])
+export default class PriceFilterDropdown extends Component {
   static propTypes = {
     className: PropTypes.string,
     theme: PropTypes.object,
     anchorText: PropTypes.node,
-    fields: PropTypes.arrayOf(PropTypes.shape({
-      label: nodeFuncOrObject,
-      value: PropTypes.string,
-      anchorLabel: nodeFuncOrObject,
-    })),
     applyButton: PropTypes.object,
     cancelButton: PropTypes.object,
   }
@@ -40,16 +29,6 @@ export default class RadioGroupDropdown extends Component {
     }
   }
 
-  get standardFields() {
-    return this.props.fields.map(originalField => {
-      const { anchorLabel, ...field } = originalField
-      return {
-        ...field,
-        checked: field.value === this.state.value,
-      }
-    })
-  }
-
   @autobind
   handleValueChange(value) {
     this.setState({ value })
@@ -57,10 +36,8 @@ export default class RadioGroupDropdown extends Component {
 
   renderAnchorButton() {
     const { value } = this.state
-    const { fields, anchorText } = this.props
-
-    const { label, anchorLabel } = fields.find(f => f.value === value) || {}
-    const text = anchorLabel || label
+    const { anchorText } = this.props
+    const text = value && `$${value.min}-$${value.max}`
 
     if (anchorText) return cloneElement(anchorText, { text })
     return <Text>{text}</Text>
@@ -69,7 +46,6 @@ export default class RadioGroupDropdown extends Component {
   render() {
     const {
       anchorText,
-      fields,
       theme,
       className,
       ...props
@@ -79,14 +55,13 @@ export default class RadioGroupDropdown extends Component {
       <Dropdown
         className={classnames(
           className,
-          theme.RadioGroupDropdown
+          theme.PriceFilterDropdown
         )}
         anchorField={{ children: this.renderAnchorButton() }}
       >
         <DropdownFilterCardWrapper
           {...props}
-          FilterCard={RadioGroupFilterCard}
-          fields={this.standardFields}
+          FilterCard={PriceFilterCard}
           handleValueChange={this.handleValueChange}
         />
       </Dropdown>

--- a/packages/react-ui-ag/src/Filters/__tests__/DropdownAnchorText-test.js
+++ b/packages/react-ui-ag/src/Filters/__tests__/DropdownAnchorText-test.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import DropdownAnchorText from '../DropdownAnchorText'
+
+describe('DropdownAnchorText', () => {
+  it('contains text that is passed in', () => {
+    const wrapper = mount(<div><DropdownAnchorText text="Bar" defaultText="Foo" /></div>)
+    expect(wrapper.text()).toContain('Bar')
+    expect(wrapper.text()).not.toContain('Foo')
+  })
+
+  it('contains defaultText if no text is passed', () => {
+    const wrapper = mount(<div><DropdownAnchorText defaultText="Foo" /></div>)
+    expect(wrapper.text()).toContain('Foo')
+  })
+
+  it('contains defaultText if text is null', () => {
+    const wrapper = mount(<div><DropdownAnchorText text={null} defaultText="Foo" /></div>)
+    expect(wrapper.text()).toContain('Foo')
+  })
+
+  it('allows a string to be passed to icon', () => {
+    const wrapper = mount(<div><DropdownAnchorText defaultText="Foo" icon="Stuff" /></div>)
+    expect(wrapper.text()).toContain('Stuff')
+  })
+
+  it('allows html to be passed to icon', () => {
+    const icon = <div data-tid="cool-stuff">cool stuff</div>
+    const wrapper = mount(<div><DropdownAnchorText defaultText="Foo" icon={icon} /></div>)
+    expect(wrapper.find('[data-tid="cool-stuff"]')).toHaveLength(1)
+  })
+})

--- a/packages/react-ui-ag/src/Filters/__tests__/DropdownFilterCardWrapper-test.js
+++ b/packages/react-ui-ag/src/Filters/__tests__/DropdownFilterCardWrapper-test.js
@@ -1,21 +1,22 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import theme from './mocks/theme'
-import RadioGroupDropdownFilterCardWrapper from '../RadioGroupDropdownFilterCardWrapper'
+import DropdownFilterCardWrapper from '../DropdownFilterCardWrapper'
 import RadioGroupFilterCard from '../RadioGroupFilterCard'
 
-describe('RadioGroupDropdownFilterCardWrapper', () => {
+describe('DropdownFilterCardWrapper', () => {
   const radioGroupFilterProps = {
     fields: [
       { label: 'Foo', value: 'o' },
       { label: 'Bar', value: 'r' },
       { label: 'Baz', value: 'z' },
     ],
+    FilterCard: RadioGroupFilterCard,
     theme,
   }
   it('injects onClick function into applyButton that calls original onClick', () => {
     const injectionProps = { ...radioGroupFilterProps, applyButton: { onClick: jest.fn() } }
-    const wrapper = shallow(<RadioGroupDropdownFilterCardWrapper {...injectionProps} />)
+    const wrapper = shallow(<DropdownFilterCardWrapper {...injectionProps} />)
     wrapper.find(RadioGroupFilterCard).props().applyButton.onClick()
     expect(injectionProps.applyButton.onClick).toHaveBeenCalled()
     expect(injectionProps.applyButton.onClick)
@@ -24,7 +25,7 @@ describe('RadioGroupDropdownFilterCardWrapper', () => {
 
   it('injects onClick function into cancelButton that calls original onClick', () => {
     const injectionProps = { ...radioGroupFilterProps, cancelButton: { onClick: jest.fn() } }
-    const wrapper = shallow(<RadioGroupDropdownFilterCardWrapper {...injectionProps} />)
+    const wrapper = shallow(<DropdownFilterCardWrapper {...injectionProps} />)
     wrapper.find(RadioGroupFilterCard).props().cancelButton.onClick()
     expect(injectionProps.cancelButton.onClick).toHaveBeenCalled()
     expect(injectionProps.cancelButton.onClick)
@@ -33,28 +34,28 @@ describe('RadioGroupDropdownFilterCardWrapper', () => {
 
   it('injects onSelect function into applyButton onClick function', () => {
     const injectionProps = { ...radioGroupFilterProps, onSelect: jest.fn() }
-    const wrapper = shallow(<RadioGroupDropdownFilterCardWrapper {...injectionProps} />)
+    const wrapper = shallow(<DropdownFilterCardWrapper {...injectionProps} />)
     wrapper.find(RadioGroupFilterCard).props().applyButton.onClick()
     expect(injectionProps.onSelect).toHaveBeenCalled()
   })
 
   it('injects onSelect function into cancelButton onClick function', () => {
     const injectionProps = { ...radioGroupFilterProps, onSelect: jest.fn() }
-    const wrapper = shallow(<RadioGroupDropdownFilterCardWrapper {...injectionProps} />)
+    const wrapper = shallow(<DropdownFilterCardWrapper {...injectionProps} />)
     wrapper.find(RadioGroupFilterCard).props().cancelButton.onClick()
     expect(injectionProps.onSelect).toHaveBeenCalled()
   })
 
   it('injects handleValueChange function into applyButton onClick function', () => {
     const injectionProps = { ...radioGroupFilterProps, handleValueChange: jest.fn() }
-    const wrapper = shallow(<RadioGroupDropdownFilterCardWrapper {...injectionProps} />)
+    const wrapper = shallow(<DropdownFilterCardWrapper {...injectionProps} />)
     wrapper.find(RadioGroupFilterCard).props().applyButton.onClick()
     expect(injectionProps.handleValueChange).toHaveBeenCalled()
   })
 
   it('injects handleValueChange function into cancelButton onClick function', () => {
     const injectionProps = { ...radioGroupFilterProps, handleValueChange: jest.fn() }
-    const wrapper = shallow(<RadioGroupDropdownFilterCardWrapper {...injectionProps} />)
+    const wrapper = shallow(<DropdownFilterCardWrapper {...injectionProps} />)
     wrapper.find(RadioGroupFilterCard).props().cancelButton.onClick()
     expect(injectionProps.handleValueChange).toHaveBeenCalled()
   })

--- a/packages/react-ui-ag/src/Filters/__tests__/PriceFilterDropdown-test.js
+++ b/packages/react-ui-ag/src/Filters/__tests__/PriceFilterDropdown-test.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import ThemedPriceFilterDropdown from '../PriceFilterDropdown'
+import PriceFilterCard from '../PriceFilterCard'
+import DropdownAnchorText from '../DropdownAnchorText'
+
+const PriceFilterDropdown = ThemedPriceFilterDropdown.WrappedComponent
+
+describe('PriceFilterDropdown', () => {
+  const props = {
+    anchorText: <DropdownAnchorText defaultText="Price" />,
+    priceSlider: {
+      formatLabel: val => `$${val}`,
+      value: { min: 500, max: 5000 },
+      minValue: 0,
+      maxValue: 15000,
+      step: 100,
+    },
+  }
+
+  it('changes the text of the dropdown anchor when value is set', () => {
+    const wrapper = mount(<PriceFilterDropdown {...props} />)
+    const value = {
+      min: 234,
+      max: 456,
+    }
+    expect(wrapper.find(DropdownAnchorText).text()).toContain('Price')
+    wrapper.setState({ value })
+    expect(wrapper.find(DropdownAnchorText).text()).toContain('$234-$456')
+  })
+
+  it('renders a PriceFilterCard when the anchor is clicked', () => {
+    const wrapper = mount(<PriceFilterDropdown {...props} />)
+    expect(wrapper.find(PriceFilterCard)).toHaveLength(0)
+    wrapper.find('button[data-tid="dropdown-anchor"]').simulate('click')
+    expect(wrapper.find(PriceFilterCard)).toHaveLength(1)
+  })
+})

--- a/packages/react-ui-ag/src/Filters/__tests__/RadioGroupDropdown-test.js
+++ b/packages/react-ui-ag/src/Filters/__tests__/RadioGroupDropdown-test.js
@@ -1,16 +1,15 @@
 import React from 'react'
 import { mount, shallow } from 'enzyme'
 import theme from './mocks/theme'
-import ThemedRadioGroupDropdown,
-{ RadioGroupDropdownAnchorText }
-  from '../RadioGroupDropdown'
-import RadioGroupDropdownFilterCardWrapper from '../RadioGroupDropdownFilterCardWrapper'
+import ThemedRadioGroupDropdown from '../RadioGroupDropdown'
+import DropdownAnchorText from '../DropdownAnchorText'
+import DropdownFilterCardWrapper from '../DropdownFilterCardWrapper'
 
 const RadioGroupDropdown = ThemedRadioGroupDropdown.WrappedComponent
 
 describe('ag/Filters/RadioGroupDropdown', () => {
   const props = {
-    anchorText: <RadioGroupDropdownAnchorText defaultText="Fubar" />,
+    anchorText: <DropdownAnchorText defaultText="Fubar" />,
     fields: [
       { anchorLabel: 'Foo!', label: 'Foo', value: 'o' },
       { anchorLabel: 'Bar!', label: 'Bar', value: 'r' },
@@ -30,7 +29,7 @@ describe('ag/Filters/RadioGroupDropdown', () => {
   it('removes anchorLabel from labels', () => {
     const wrapper = shallow(<RadioGroupDropdown {...props} />)
     expect(
-      wrapper.find(RadioGroupDropdownFilterCardWrapper).props().fields.filter(f => f.anchorLabel)
+      wrapper.find(DropdownFilterCardWrapper).props().fields.filter(f => f.anchorLabel)
     ).toHaveLength(0)
   })
 })

--- a/packages/react-ui-ag/src/Filters/index.js
+++ b/packages/react-ui-ag/src/Filters/index.js
@@ -1,4 +1,6 @@
 export { default as FilterCard } from './FilterCard'
 export { default as RadioGroupFilterCard } from './RadioGroupFilterCard'
 export { default as PriceFilterCard } from './PriceFilterCard'
-export { default as RadioGroupDropdown, RadioGroupDropdownAnchorText } from './RadioGroupDropdown'
+export { default as RadioGroupDropdown } from './RadioGroupDropdown'
+export { default as PriceFilterDropdown } from './PriceFilterDropdown'
+export { default as DropdownAnchorText } from './DropdownAnchorText'

--- a/packages/react-ui-ag/src/index.js
+++ b/packages/react-ui-ag/src/index.js
@@ -3,7 +3,8 @@ export {
   RadioGroupFilterCard,
   PriceFilterCard,
   RadioGroupDropdown,
-  RadioGroupDropdownAnchorText,
+  PriceFilterDropdown,
+  DropdownAnchorText,
 } from './Filters'
 
 export {

--- a/stories/ag/Filters/PriceFilterDropdown.js
+++ b/stories/ag/Filters/PriceFilterDropdown.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import themed from 'react-themed'
+import classnames from 'classnames'
+import { action } from '@storybook/addon-actions'
+import { PriceFilterDropdown, DropdownAnchorText } from 'react-ui-ag/src'
+
+const DesktopPriceFilterDropdownComponent = ({ theme }) => (
+  <PriceFilterDropdown
+    className={classnames(theme.SearchFilter, theme.PriceFilterCard)}
+    anchorText={<DropdownAnchorText defaultText="Price" />}
+    priceSlider={{
+      formatLabel: val => `$${val}`,
+      value: { min: 500, max: 5000 },
+      minValue: 0,
+      maxValue: 15000,
+      step: 100,
+    }}
+    applyButton={{ onClick: value => { action('onChangeComplete')(`applied($${(value || {}).min} - $${(value || {}).max})`) } }}
+    cancelButton={{ onClick: () => { action('onChangeComplete')('canceled price') } }}
+    onChange={price => action('Desktop Price Change')(`$${price.min} - $${price.max}`)}
+  />
+)
+DesktopPriceFilterDropdownComponent.propTypes = {
+  theme: PropTypes.object,
+}
+const ThemedDesktopPriceFilterDropdown = themed(['SearchFilter', 'PriceFilterCard'])(DesktopPriceFilterDropdownComponent)
+const DesktopPriceFilterDropdown = <ThemedDesktopPriceFilterDropdown />
+
+export { DesktopPriceFilterDropdown }

--- a/stories/ag/Filters/RadioGroupDropdown.js
+++ b/stories/ag/Filters/RadioGroupDropdown.js
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types'
 import themed from 'react-themed'
 import classnames from 'classnames'
 import { action } from '@storybook/addon-actions'
-import { RadioGroupDropdown, RadioGroupDropdownAnchorText } from 'react-ui-ag/src'
+import { RadioGroupDropdown, DropdownAnchorText } from 'react-ui-ag/src'
 
 const DesktopBedroomDropdownComponent = ({ theme }) => (
   <RadioGroupDropdown
     className={theme.SearchFilter}
-    anchorText={<RadioGroupDropdownAnchorText defaultText="Bed" />}
+    anchorText={<DropdownAnchorText defaultText="Bed" />}
     fields={[
       { anchorLabel: '', label: 'Any', value: '' },
       { anchorLabel: 'Studio', label: 'Studio', value: '0' },
@@ -34,7 +34,7 @@ const DesktopBedroomDropdown = <ThemedDesktopBedroomDropdown />
 const DesktopBathroomDropdownComponent = ({ theme }) => (
   <RadioGroupDropdown
     className={classnames(theme.SearchFilter, theme.BathroomFilterCard)}
-    anchorText={<RadioGroupDropdownAnchorText defaultText="Bath" />}
+    anchorText={<DropdownAnchorText defaultText="Bath" />}
     fields={[
       { anchorLabel: '1+ Baths', label: '1+', value: '1' },
       { anchorLabel: '2+ Baths', label: '2+', value: '2' },
@@ -57,7 +57,7 @@ const DesktopBathroomDropdown = <ThemedDesktopBathroomDropdown />
 const DesktopPetDropdownComponent = ({ theme }) => (
   <RadioGroupDropdown
     className={classnames(theme.SearchFilter, theme.PetFilterCard)}
-    anchorText={<RadioGroupDropdownAnchorText defaultText="Pets" />}
+    anchorText={<DropdownAnchorText defaultText="Pets" />}
     fields={[
       { label: 'Dogs', value: 'dogs' },
       { label: 'Cats', value: 'cats' },

--- a/stories/ag/Filters/index.js
+++ b/stories/ag/Filters/index.js
@@ -24,3 +24,7 @@ export {
   DesktopBathroomDropdown,
   DesktopPetDropdown,
 } from './RadioGroupDropdown'
+
+export {
+  DesktopPriceFilterDropdown,
+} from './PriceFilterDropdown'

--- a/stories/ag/index.js
+++ b/stories/ag/index.js
@@ -19,6 +19,7 @@ import {
   DesktopBedroomDropdown,
   DesktopBathroomDropdown,
   DesktopPetDropdown,
+  DesktopPriceFilterDropdown,
 } from './Filters'
 
 const AgThemeSmallDecorator = storyFn => (
@@ -72,8 +73,13 @@ storiesOf('react-ui-ag / Filters / PriceFilterCard / small', module)
   .add('Price Filter', () => InlinePriceFilterCard)
 
 storiesOf('react-ui-ag / Filters / RadioGroupDropdown / large', module)
-  .addDecorator((story, context) => withInfo('PriceFilterCard')(story)(context))
+  .addDecorator((story, context) => withInfo('RadioGroupDropdown')(story)(context))
   .addDecorator(AgThemeLargeDecorator)
   .add('Beds', () => DesktopBedroomDropdown)
   .add('Baths', () => DesktopBathroomDropdown)
   .add('Pets', () => DesktopPetDropdown)
+
+storiesOf('react-ui-ag / Filters / PriceFilterDropdown / large', module)
+  .addDecorator((story, context) => withInfo('PriceFilterDropdown')(story)(context))
+  .addDecorator(AgThemeLargeDecorator)
+  .add('Price Filter', () => DesktopPriceFilterDropdown)

--- a/stories/theme/ag/large/Dropdown.css
+++ b/stories/theme/ag/large/Dropdown.css
@@ -5,14 +5,3 @@
 .Dropdown .Card {
   z-index: 1;
 }
-
-.Dropdown .Card::before {
-  background-color: #fff;
-  content: "";
-  height: 15px;
-  width: 96px;
-  z-index: 1;
-  position: absolute;
-  top: 26px;
-  left: 10px;
-}

--- a/stories/theme/ag/large/DropdownAnchor.css
+++ b/stories/theme/ag/large/DropdownAnchor.css
@@ -26,3 +26,18 @@
 .DropdownAnchor.PetFilterCard {
   width: 126px;
 }
+
+.DropdownAnchor.PriceFilterCard {
+  width: 149px;
+}
+
+.DropdownAnchor-expand::after {
+  background-color: #fff;
+  content: "";
+  height: 15px;
+  width: inherit;
+  z-index: 1;
+  position: absolute;
+  top: 26px;
+  left: 10px;
+}

--- a/stories/theme/ag/large/Filters/PetFilterCard.css
+++ b/stories/theme/ag/large/Filters/PetFilterCard.css
@@ -1,7 +1,3 @@
 .PetFilterCard .Card {
   height: 138px;
 }
-
-.RadioGroupDropdown.PetFilterCard .Card::before {
-  width: 126px;
-}

--- a/stories/theme/ag/large/Filters/PriceFilterCard.css
+++ b/stories/theme/ag/large/Filters/PriceFilterCard.css
@@ -1,4 +1,4 @@
-.SearchFilter.PriceFilterCard {
+.SearchFilter.PriceFilterCard.Card {
   padding: 0 25px;
 }
 


### PR DESCRIPTION
[Story](https://rentpath.leankit.com/card/595591548)

* renamed RadioGroupDropdownFilterCardWrapper to DropdownFilterCardWrapper
* generalized DropdownFilterCardWrapper to accept different filter cards
* moved DropdownAnchorText to its own file for use in different dropdowns
* created PriceFilterDropdown
* moved Dropdown card ::before logic to DropdownAnchor::after, sizes dynamically