### PR TITLE
chore(script): publish script needs registry set

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint:js:fix": "lerna packages stories --fix",
     "postinstall": "lerna bootstrap",
     "prepublish": "lerna run clean --yes && lerna run build",
-    "publish-packages": "lerna publish --exact --conventional-commits",
+    "publish-packages": "lerna publish --exact --conventional-commits --registry=https://registry.npmjs.org/",
     "storybook": "start-storybook -p 6006 -c .storybook -s ./.storybook/dist",
     "build-storybook": "build-storybook"
   },


### PR DESCRIPTION
[Card](https://rentpath.leankit.com/card/602636449)
Fixing publish script. Breaks without registry when using yarn command