### PR TITLE
fix(storybook): addon package needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@storybook/addon-knobs": "3.3.10",
     "@storybook/addon-options": "3.3.10",
     "@storybook/addon-viewport": "3.3.10",
+    "@storybook/addons": "^3.3.10",
     "@storybook/react": "3.3.10",
     "@types/node": "9.3.0",
     "@types/react": "16.0.34",


### PR DESCRIPTION
Upgrade of storybook package broken due to missing @storybook/addons needing to be added

https://storybook.js.org/basics/faq/#why-is-there-no-addons-channel