### PR TITLE
chore(travis): setup S3 publishing for review envs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ packages/**/yarn.lock
 packages/**/package-lock.json
 coverage
 build
+artifacts

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,25 @@ script:
   - yarn run test:ci
   - yarn run build-storybook
 
+after_success:
+  - mkdir artifacts && cp -R build artifacts/$TRAVIS_BRANCH-${TRAVIS_COMMIT:0:7} && cp -R .storybook/dist/* artifacts/ 
+
 deploy:
-  provider: pages
-  skip-cleanup: true
-  github-token: $GITHUB_TOKEN  # Set env matrix, marked secure
-  keep-history: true
-  local-dir: build
-  on:
-    branch: master
+  - provider: s3
+    skip_cleanup: true
+    access_key_id: $ARTIFACTS_KEY
+    secret_access_key: $ARTIFACTS_SECRET
+    bucket: $ARTIFACTS_BUCKET
+    region: us-east-1
+    acl: public_read
+    local-dir: artifacts
+    on:
+      all_branches: true
+
+  - provider: pages
+    skip-cleanup: true
+    github-token: $GITHUB_TOKEN  # Set env matrix, marked secure
+    keep-history: true
+    local-dir: build
+    on:
+      branch: master

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "report-coverage": "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls",
     "storybook": "start-storybook -p 6006 -c .storybook -s ./.storybook/dist",
     "test": "./node_modules/.bin/jest --coverage",
-    "test:ci": "./node_modules/.bin/jest --coverage --maxWorkers=2 && yarn run report-coverage",
+    "test:ci": "yarn run test --maxWorkers=2 && yarn run report-coverage",
     "test:coverage": "yarn run test && yarn run report-coverage"
   },
   "jest": {


### PR DESCRIPTION
affects: @rentpath/react-ui-ag, @rentpath/react-ui-core, @rentpath/react-ui-rent,
@rentpath/react-ui-rentals, @rentpath/react-ui-tracking, @rentpath/react-ui-utils

Upload the storybook build to an S3 bucket to provide the same functionality
as review envs, but these deployments are permanent.