### PR TITLE
chore(travis): force push gh-pages on master build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ deploy:
   - provider: pages
     skip-cleanup: true
     github-token: $GITHUB_TOKEN  # Set env matrix, marked secure
-    keep-history: true
     local-dir: build
     on:
       branch: master


### PR DESCRIPTION
affects: @rentpath/react-ui-ag, @rentpath/react-ui-core, @rentpath/react-ui-rent,
@rentpath/react-ui-rentals, @rentpath/react-ui-tracking, @rentpath/react-ui-utils