### PR TITLE
feat(Rating Star): add strokeWidth override inside the RatingBar's Star

### DIFF
--- a/packages/react-ui-core/src/Ratings/Star.js
+++ b/packages/react-ui-core/src/Ratings/Star.js
@@ -8,11 +8,13 @@ export default class Star extends Component {
     fillColor: PropTypes.string.isRequired,
     backgroundFillColor: PropTypes.string,
     width: PropTypes.string,
+    strokeWidth: PropTypes.string,
     className: PropTypes.string,
   }
 
   static defaultProps = {
     width: '0',
+    strokeWidth: '3',
   }
 
   render() {
@@ -21,6 +23,7 @@ export default class Star extends Component {
       fillColor,
       backgroundFillColor,
       width,
+      strokeWidth,
       className,
       ...props
     } = this.props
@@ -42,7 +45,7 @@ export default class Star extends Component {
           <path
             fill={`url(#${uniqueId})`}
             stroke="#000"
-            strokeWidth="3"
+            strokeWidth={strokeWidth}
             d="m25,1 6,17h18l-14,11 5,17-15-10-15,10 5-17-14-11h18z"
           />
         </svg>

--- a/packages/react-ui-core/src/Ratings/__tests__/Star-test.js
+++ b/packages/react-ui-core/src/Ratings/__tests__/Star-test.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import Star from '../Star'
+
+describe('Star', () => {
+  const props = {
+    uniqueId: '123',
+    fillColor: 'yellow',
+  }
+
+  it('has a default strokeWidth of 3', () => {
+    const wrapper = shallow(<Star {...props} />)
+    expect(wrapper.find('path').prop('strokeWidth')).toEqual('3')
+  })
+
+  it('allows strokeWidth to be overridden', () => {
+    const wrapper = shallow(<Star {...props} strokeWidth="0" />)
+    expect(wrapper.find('path').prop('strokeWidth')).toEqual('0')
+  })
+})


### PR DESCRIPTION
affects: @rentpath/react-ui-core

[Story](https://rentpath.leankit.com/card/615297106)

* add prop to allow override of strokeWidth inside the RatingBar's Star