### PR TITLE
feat(Hybrid Map): add classname for mobile map listing for active and inactive

### DIFF
--- a/packages/react-ui-ag/CHANGELOG.md
+++ b/packages/react-ui-ag/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.7.1"></a>
+## [0.7.1](https://github.com/rentpath/react-ui/compare/@rentpath/react-ui-ag@0.7.0...@rentpath/react-ui-ag@0.7.1) (2018-02-08)
+
+
+
+
+**Note:** Version bump only for package @rentpath/react-ui-ag
+
 <a name="0.7.0"></a>
 # [0.7.0](https://github.com/rentpath/react-ui/compare/@rentpath/react-ui-ag@0.6.0...@rentpath/react-ui-ag@0.7.0) (2018-02-02)
 

--- a/packages/react-ui-ag/package.json
+++ b/packages/react-ui-ag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rentpath/react-ui-ag",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {
@@ -48,7 +48,7 @@
     "react-test-renderer": "16.2.0"
   },
   "dependencies": {
-    "@rentpath/react-ui-core": "4.2.1",
+    "@rentpath/react-ui-core": "4.3.0",
     "@rentpath/react-ui-utils": "1.0.3",
     "classnames": "2.2.5",
     "prop-types": "15.6.0",

--- a/packages/react-ui-ag/src/Carousels/ListingCarousel.js
+++ b/packages/react-ui-ag/src/Carousels/ListingCarousel.js
@@ -63,7 +63,7 @@ export default class ListingCarousel extends Component {
         index={index}
         listing={listing}
         {...props}
-        prioritizeCardClick={index !== this.state.selectedIndex}
+        isActive={index === this.state.selectedIndex}
         onClick={this.listingClickHandler}
       />
     )

--- a/packages/react-ui-ag/src/Listings/MobileMapListing.js
+++ b/packages/react-ui-ag/src/Listings/MobileMapListing.js
@@ -28,11 +28,11 @@ export default class MobileMapListing extends PureComponent {
     propertyName: PropTypes.object,
     ctaButtons: PropTypes.arrayOf(buttonPropTypes),
     favoriteButton: buttonPropTypes,
-    prioritizeCardClick: PropTypes.bool,
+    isActive: PropTypes.bool,
   }
 
   static defaultProps = {
-    prioritizeCardClick: false,
+    isActive: true,
     theme: {},
     listing: {},
     ratings: {},
@@ -48,19 +48,31 @@ export default class MobileMapListing extends PureComponent {
 
   @autobind
   handleButtonClick(onClick) {
-    return event => {
-      const { prioritizeCardClick } = this.props
+    const { isActive } = this.props
 
-      if (!prioritizeCardClick && onClick) {
+    return event => {
+      if (isActive && onClick) {
         onClick(this.props.listing)
-      } else if (prioritizeCardClick && this.props.onClick) {
+      } else if (!isActive && this.props.onClick) {
         this.props.onClick(this.props.index)
       }
 
       const shouldStopPropagation =
-        !prioritizeCardClick && event && event.stopPropagation
+        isActive && event && event.stopPropagation
 
       if (shouldStopPropagation) event.stopPropagation()
+    }
+  }
+
+  @autobind
+  handleFavoriteClick(value) {
+    const { isActive, favoriteButton } = this.props
+    const { onClick } = favoriteButton
+
+    if (isActive && onClick) {
+      onClick(this.props.listing, value)
+    } else if (!isActive && this.props.onClick) {
+      this.props.onClick(this.props.index)
     }
   }
 
@@ -79,6 +91,10 @@ export default class MobileMapListing extends PureComponent {
       ...buttonProps
     } = props
 
+    const buttonText = get(listing, valueLocation, children)
+
+    if (!buttonText) return null
+
     return (
       <Button
         {...buttonProps}
@@ -90,14 +106,14 @@ export default class MobileMapListing extends PureComponent {
         key={key}
         data-tid="cta-button"
       >
-        {get(listing, valueLocation, children)}
+        {buttonText}
       </Button>
     )
   }
 
   renderFavoriteButton() {
-    const { theme, favoriteButton } = this.props
-    const { className, onClick } = favoriteButton
+    const { theme, favoriteButton, isActive } = this.props
+    const { className } = favoriteButton
     return (
       <ToggleButton
         {...favoriteButton}
@@ -105,7 +121,8 @@ export default class MobileMapListing extends PureComponent {
           theme.MobileMapListing_FavoriteButton,
           className,
         )}
-        onClick={this.handleButtonClick(onClick)}
+        inactive={!isActive}
+        onClick={this.handleFavoriteClick}
       />
     )
   }
@@ -121,7 +138,7 @@ export default class MobileMapListing extends PureComponent {
       ctaButtons,
       favoriteButton,
       propertyName,
-      prioritizeCardClick,
+      isActive,
       ...props
     } = this.props
 
@@ -129,7 +146,12 @@ export default class MobileMapListing extends PureComponent {
       <ListingCell
         listing={listing}
         onClick={this.handleCardClick}
-        className={theme.MobileMapListing}
+        className={classnames(
+          className,
+          theme.MobileMapListing,
+          theme[`MobileMapListing-${isActive ? 'active' : 'inactive'}`]
+        )}
+        isActive={isActive}
         {...props}
       >
         {this.renderFavoriteButton()}

--- a/packages/react-ui-ag/src/Listings/SingleFamilyMobileMapListing.js
+++ b/packages/react-ui-ag/src/Listings/SingleFamilyMobileMapListing.js
@@ -24,13 +24,14 @@ export default class SingleFamilyMobileMapListing extends PureComponent {
     photos: PropTypes.object,
     ctaButton: buttonPropTypes,
     favoriteButton: buttonPropTypes,
-    prioritizeCardClick: PropTypes.bool,
+    isActive: PropTypes.bool,
   }
 
   static defaultProps = {
     theme: {},
     listing: {},
     ctaButton: {},
+    isActive: true,
   }
 
   @autobind
@@ -42,25 +43,38 @@ export default class SingleFamilyMobileMapListing extends PureComponent {
 
   @autobind
   handleButtonClick(onClick) {
-    return event => {
-      const { prioritizeCardClick } = this.props
+    const { isActive } = this.props
 
-      if (!prioritizeCardClick && onClick) {
+    return event => {
+      if (isActive && onClick) {
         onClick(this.props.listing)
-      } else if (prioritizeCardClick && this.props.onClick) {
+      } else if (!isActive && this.props.onClick) {
         this.props.onClick(this.props.index)
       }
 
       const shouldStopPropagation =
-        !prioritizeCardClick && event && event.stopPropagation
+        isActive && event && event.stopPropagation
 
       if (shouldStopPropagation) event.stopPropagation()
+    }
+  }
+
+  @autobind
+  handleFavoriteClick(value) {
+    const { isActive, favoriteButton } = this.props
+    const { onClick } = favoriteButton
+
+    if (isActive && onClick) {
+      onClick(this.props.listing, value)
+    } else if (!isActive && this.props.onClick) {
+      this.props.onClick(this.props.index)
     }
   }
 
   renderCtaButton() {
     const { theme, ctaButton } = this.props
     const { onClick, className } = ctaButton
+
     return (
       <Button
         {...ctaButton}
@@ -75,8 +89,8 @@ export default class SingleFamilyMobileMapListing extends PureComponent {
   }
 
   renderFavoriteButton() {
-    const { theme, favoriteButton } = this.props
-    const { className, onClick } = favoriteButton
+    const { theme, favoriteButton, isActive } = this.props
+    const { className } = favoriteButton
     return (
       <ToggleButton
         {...favoriteButton}
@@ -84,7 +98,8 @@ export default class SingleFamilyMobileMapListing extends PureComponent {
           theme.MobileMapListing_FavoriteButton,
           className,
         )}
-        onClick={this.handleButtonClick(onClick)}
+        onClick={this.handleFavoriteClick}
+        inactive={!isActive}
       />
     )
   }
@@ -97,8 +112,8 @@ export default class SingleFamilyMobileMapListing extends PureComponent {
       className,
       photos,
       ctaButton,
-      prioritizeCardClick,
       favoriteButton,
+      isActive,
       ...props
     } = this.props
 
@@ -106,7 +121,12 @@ export default class SingleFamilyMobileMapListing extends PureComponent {
       <ListingCell
         listing={listing}
         onClick={this.handleCardClick}
-        className={theme.MobileMapListing}
+        className={classnames(
+          className,
+          theme.MobileMapListing,
+          theme[`MobileMapListing-${isActive ? 'active' : 'inactive'}`]
+        )}
+        isActive={isActive}
         {...props}
       >
         {this.renderFavoriteButton()}

--- a/packages/react-ui-ag/src/Listings/__tests__/MobileMapListing-test.js
+++ b/packages/react-ui-ag/src/Listings/__tests__/MobileMapListing-test.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { shallow, mount } from 'enzyme'
 import { Button, RatingBar, ToggleButton } from '@rentpath/react-ui-core'
 import ThemedMobileMapListing from '../MobileMapListing'
+import theme from './mocks/theme'
 
 const MobileMapListing = ThemedMobileMapListing.WrappedComponent
 
@@ -34,6 +35,7 @@ const baseListing = {
 
 const props = {
   listing: baseListing,
+  theme,
   onClick: () => { },
   navigation: {
     next: {
@@ -43,7 +45,6 @@ const props = {
       children: 'Previous',
     },
   },
-  prioritizeCardClick: false,
   ctaButtons: [
     {
       valueLocation: 'phone',
@@ -78,11 +79,23 @@ describe('ag/Listing/MobileMapListing', () => {
       wrapper = shallow(
         <MobileMapListing
           {...props}
-          ctaButtons={[{ onClick: ctaClick }, { onClick: ctaClick }]}
+          ctaButtons={[{ children: 'foo', onClick: ctaClick }, { children: 'bar', onClick: ctaClick }]}
           onClick={cardClick}
-          prioritizeCardClick={false}
+          isActive
         />
       )
+    })
+
+    it('does not render a cta button if there is no text to display in the button', () => {
+      wrapper = shallow(
+        <MobileMapListing
+          {...props}
+          ctaButtons={[{ onClick: ctaClick }, { children: 'bar', onClick: ctaClick }]}
+          onClick={cardClick}
+          isActive
+        />
+      )
+      expect(wrapper.find(Button).length).toEqual(1)
     })
 
     it('handle an array of cta buttons', () => {
@@ -95,13 +108,13 @@ describe('ag/Listing/MobileMapListing', () => {
       expect(ctaClick.mock.calls).toHaveLength(2)
     })
 
-    it('fires cta buttons on click action when prioritizeCardClick is true', () => {
+    it('fires cta buttons on click action when isActive is false', () => {
       wrapper = shallow(
         <MobileMapListing
           {...props}
-          ctaButtons={[{ onClick: ctaClick }, { onClick: ctaClick }]}
+          ctaButtons={[{ children: 'foo', onClick: ctaClick }, { children: 'bar', onClick: ctaClick }]}
           onClick={cardClick}
-          prioritizeCardClick
+          isActive={false}
         />)
       wrapper.find('[data-tid="cta-button"]').at(0).simulate('click')
       wrapper.find('[data-tid="cta-button"]').at(1).simulate('click')
@@ -111,14 +124,14 @@ describe('ag/Listing/MobileMapListing', () => {
 
   it('fires favoriteButton click action on favorite button click', () => {
     const favoriteClick = jest.fn()
-    const wrapper = shallow(
+    const wrapper = mount(
       <MobileMapListing
         {...props}
         favoriteButton={{ onClick: favoriteClick }}
       />
     )
     wrapper.find(ToggleButton).simulate('click')
-    expect(favoriteClick).toHaveBeenCalled()
+    expect(favoriteClick).toHaveBeenCalledWith(baseListing, true)
   })
 
   it('does not fire cardClick on favorite button click', () => {
@@ -177,5 +190,15 @@ describe('ag/Listing/MobileMapListing', () => {
     const wrapper = mount(<MobileMapListing {...props} />)
     expect(wrapper.find('[data-tid="bedroom"]').at(0).text()).toEqual(baseListing.bedrooms)
     expect(wrapper.find(RatingBar).props().score).toEqual(4)
+  })
+
+  it('adds a inactive theme if the listing is inactive', () => {
+    const wrapper = shallow(<MobileMapListing {...props} isActive={false} />)
+    expect(wrapper.hasClass('MobileMapListing-inactive')).toBeTruthy()
+  })
+
+  it('adds a active theme if the listing is active', () => {
+    const wrapper = shallow(<MobileMapListing {...props} isActive />)
+    expect(wrapper.hasClass('MobileMapListing-active')).toBeTruthy()
   })
 })

--- a/packages/react-ui-ag/src/Listings/__tests__/SingleFamilyMobileMapListing-test.js
+++ b/packages/react-ui-ag/src/Listings/__tests__/SingleFamilyMobileMapListing-test.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import { shallow, mount } from 'enzyme'
-import { ToggleButton } from '@rentpath/react-ui-core'
+import { ToggleButton, Button } from '@rentpath/react-ui-core'
 import ThemedSingleFamilyMobileMapListing from '../SingleFamilyMobileMapListing'
+import theme from './mocks/theme'
 
 const SingleFamilyMobileMapListing = ThemedSingleFamilyMobileMapListing.WrappedComponent
 
@@ -26,6 +27,7 @@ const props = {
   server: '',
   dimensions: '280-120',
   listing: baseListing,
+  theme,
   onClick: () => { },
   navigation: {
     next: {
@@ -56,11 +58,12 @@ describe('ag/Listing/SingleFamilyMobileMapListing', () => {
         ctaButton={{ onClick: ctaClick }}
       />
     )
-    wrapper.find('[data-tid="cta-button"]').simulate('click')
+
+    wrapper.find(Button).simulate('click')
     expect(ctaClick).toHaveBeenCalled()
   })
 
-  it('fires cta buttons on click action when prioritizeCardClick is true', () => {
+  it('fires cta buttons on click action when isActive is false', () => {
     const ctaClick = jest.fn()
     const cardClick = jest.fn()
     const wrapper = shallow(
@@ -68,7 +71,7 @@ describe('ag/Listing/SingleFamilyMobileMapListing', () => {
         {...props}
         ctaButtons={{ onClick: ctaClick }}
         onClick={cardClick}
-        prioritizeCardClick
+        isActive={false}
       />)
     wrapper.find('[data-tid="cta-button"]').at(0).simulate('click')
     expect(cardClick.mock.calls).toHaveLength(1)
@@ -76,14 +79,14 @@ describe('ag/Listing/SingleFamilyMobileMapListing', () => {
 
   it('fires favoriteButton click action on favorite button click', () => {
     const favoriteClick = jest.fn()
-    const wrapper = shallow(
+    const wrapper = mount(
       <SingleFamilyMobileMapListing
         {...props}
         favoriteButton={{ onClick: favoriteClick }}
       />
     )
     wrapper.find(ToggleButton).simulate('click')
-    expect(favoriteClick).toHaveBeenCalled()
+    expect(favoriteClick).toHaveBeenCalledWith(baseListing, true)
   })
 
   it('does not fire cardClick on favorite button click', () => {
@@ -138,5 +141,15 @@ describe('ag/Listing/SingleFamilyMobileMapListing', () => {
   it('populates components from listing object prop', () => {
     const wrapper = mount(<SingleFamilyMobileMapListing {...props} />)
     expect(wrapper.find('[data-tid="bedroom"]').at(0).text()).toEqual(baseListing.bedrooms)
+  })
+
+  it('adds a inactive theme if the listing is inactive', () => {
+    const wrapper = shallow(<SingleFamilyMobileMapListing {...props} isActive={false} />)
+    expect(wrapper.hasClass('MobileMapListing-inactive')).toBeTruthy()
+  })
+
+  it('adds a active theme if the listing is active', () => {
+    const wrapper = shallow(<SingleFamilyMobileMapListing {...props} isActive />)
+    expect(wrapper.hasClass('MobileMapListing-active')).toBeTruthy()
   })
 })

--- a/packages/react-ui-ag/src/Listings/__tests__/mocks/theme.js
+++ b/packages/react-ui-ag/src/Listings/__tests__/mocks/theme.js
@@ -1,9 +1,7 @@
 import { keyMirror } from '@rentpath/react-ui-utils'
 
 export default keyMirror([
-  'Carousel',
   'MobileMapListing',
-  'ToggleButton',
-  'RatingBar',
-  'Button',
+  'MobileMapListing-active',
+  'MobileMapListing-inactive',
 ])

--- a/packages/react-ui-core/CHANGELOG.md
+++ b/packages/react-ui-core/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.3.0"></a>
+# [4.3.0](https://github.com/rentpath/react-ui/compare/@rentpath/react-ui-core@4.2.1...@rentpath/react-ui-core@4.3.0) (2018-02-08)
+
+
+### Features
+
+* **Rating Star:** add strokeWidth override inside the RatingBar's Star ([8f63b58](https://github.com/rentpath/react-ui/commit/8f63b58))
+
+
+
+
 <a name="4.2.1"></a>
 ## [4.2.1](https://github.com/rentpath/react-ui/compare/@rentpath/react-ui-core@4.2.0...@rentpath/react-ui-core@4.2.1) (2018-01-31)
 

--- a/packages/react-ui-core/package.json
+++ b/packages/react-ui-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rentpath/react-ui-core",
-  "version": "4.2.1",
+  "version": "4.3.0",
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {

--- a/packages/react-ui-core/src/Button/ToggleButton.js
+++ b/packages/react-ui-core/src/Button/ToggleButton.js
@@ -14,6 +14,7 @@ export default class ToggleButton extends Component {
     children: PropTypes.node,
     value: PropTypes.bool,
     onClick: PropTypes.func,
+    inactive: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -39,11 +40,16 @@ export default class ToggleButton extends Component {
 
   @autobind
   toggle() {
-    const { onClick } = this.props
-    const value = !this.state.value
-    this.setState({
-      value,
-    })
+    const { onClick, inactive } = this.props
+
+    const value = inactive ? this.state.value : !this.state.value
+
+    if (!inactive) {
+      this.setState({
+        value,
+      })
+    }
+
     if (onClick) onClick(value)
   }
 
@@ -54,6 +60,7 @@ export default class ToggleButton extends Component {
       children,
       onClick,
       value,
+      inactive,
       ...props
     } = this.props
 

--- a/packages/react-ui-core/src/Button/__tests__/ToggleButton-test.js
+++ b/packages/react-ui-core/src/Button/__tests__/ToggleButton-test.js
@@ -55,7 +55,7 @@ describe('ToggleButton', () => {
     expect(wrapper.hasClass('ToggleButton-on')).not.toBeTruthy()
   })
 
-  it('It fires callback function which returns alternating true and false', () => {
+  it('fires callback function which returns alternating true and false', () => {
     const props = {
       theme,
       className: theme.ToggleButton,
@@ -70,5 +70,18 @@ describe('ToggleButton', () => {
     expect(onClick.mock.calls[1][0]).toEqual(false)
     wrapper.simulate('click')
     expect(onClick.mock.calls[2][0]).toEqual(true)
+  })
+
+  it.only('does not toggle when inactive is true', () => {
+    const props = {
+      theme,
+      className: theme.ToggleButton,
+      children: <a href="#">Toggle</a>,
+    }
+    const onClick = jest.fn()
+
+    const wrapper = shallow(<ToggleButton onClick={onClick} {...props} inactive />)
+    wrapper.simulate('click')
+    expect(onClick.mock.calls[0][0]).toEqual(false)
   })
 })

--- a/packages/react-ui-core/src/Listing/ListingCell.js
+++ b/packages/react-ui-core/src/Listing/ListingCell.js
@@ -15,7 +15,7 @@ export default class ListingCell extends Component {
     theme: PropTypes.object,
     className: PropTypes.string,
     onClick: PropTypes.func,
-    prioritizeCardClick: PropTypes.bool,
+    isActive: PropTypes.bool,
   }
 
   static childContextTypes = {
@@ -37,6 +37,7 @@ export default class ListingCell extends Component {
   }
 
   static defaultProps = {
+    isActive: true,
     theme: {},
     listing: {},
   }
@@ -58,19 +59,15 @@ export default class ListingCell extends Component {
 
   shouldComponentUpdate(nextProps) {
     return !isEqual(nextProps.listing, this.props.listing)
-      || this.props.prioritizeCardClick !== nextProps.prioritizeCardClick
+      || this.props.isActive !== nextProps.isActive
   }
 
   @autobind
   handleClick(event) {
-    const { onClick, prioritizeCardClick } = this.props
+    const { onClick, isActive } = this.props
 
-    if (!onClick) return
-
-    if (prioritizeCardClick) {
-      onClick()
-    } else if (!event || event.target.tagName !== 'BUTTON') {
-      onClick()
+    if (!isActive || !event || event.target.tagName !== 'BUTTON') {
+      if (onClick) onClick()
     }
   }
 
@@ -81,7 +78,7 @@ export default class ListingCell extends Component {
       children,
       listing,
       onClick,
-      prioritizeCardClick,
+      isActive,
       ...props
     } = this.props
 

--- a/packages/react-ui-core/src/Listing/__tests__/ListingCell-test.js
+++ b/packages/react-ui-core/src/Listing/__tests__/ListingCell-test.js
@@ -56,10 +56,10 @@ describe('ListingCell', () => {
     expect(cardClick).toHaveBeenCalled()
   })
 
-  it('fires a card click on a button click if prioritizeCardClick is true', () => {
+  it('fires a card click on a button click if isActive is false', () => {
     const cardClick = jest.fn()
     const wrapper = mount(
-      <ListingCell listing={listing} onClick={cardClick} prioritizeCardClick>
+      <ListingCell listing={listing} onClick={cardClick} isActive={false}>
         <button data-tid="fake-button" />
       </ListingCell>
     )

--- a/packages/react-ui-rent/CHANGELOG.md
+++ b/packages/react-ui-rent/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.3.9"></a>
+## [0.3.9](https://github.com/rentpath/react-ui/compare/@rentpath/react-ui-rent@0.3.8...@rentpath/react-ui-rent@0.3.9) (2018-02-08)
+
+
+
+
+**Note:** Version bump only for package @rentpath/react-ui-rent
+
 <a name="0.3.8"></a>
 ## [0.3.8](https://github.com/rentpath/react-ui/compare/@rentpath/react-ui-rent@0.3.7...@rentpath/react-ui-rent@0.3.8) (2018-01-31)
 

--- a/packages/react-ui-rent/package.json
+++ b/packages/react-ui-rent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rentpath/react-ui-rent",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {
@@ -47,7 +47,7 @@
     "react-test-renderer": "16.2.0"
   },
   "dependencies": {
-    "@rentpath/react-ui-core": "4.2.1",
+    "@rentpath/react-ui-core": "4.3.0",
     "@rentpath/react-ui-utils": "1.0.3",
     "classnames": "2.2.5",
     "prop-types": "15.6.0",

--- a/packages/react-ui-rentals/CHANGELOG.md
+++ b/packages/react-ui-rentals/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.1.6"></a>
+## [0.1.6](https://github.com/rentpath/react-ui/compare/@rentpath/react-ui-rentals@0.1.5...@rentpath/react-ui-rentals@0.1.6) (2018-02-08)
+
+
+
+
+**Note:** Version bump only for package @rentpath/react-ui-rentals
+
 <a name="0.1.5"></a>
 ## [0.1.5](https://github.com/rentpath/react-ui/compare/@rentpath/react-ui-rentals@0.1.4...@rentpath/react-ui-rentals@0.1.5) (2018-01-31)
 

--- a/packages/react-ui-rentals/package.json
+++ b/packages/react-ui-rentals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rentpath/react-ui-rentals",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {
@@ -47,7 +47,7 @@
     "react-test-renderer": "16.2.0"
   },
   "dependencies": {
-    "@rentpath/react-ui-core": "4.2.1",
+    "@rentpath/react-ui-core": "4.3.0",
     "@rentpath/react-ui-utils": "1.0.3",
     "classnames": "2.2.5",
     "prop-types": "15.6.0",

--- a/stories/ag/Carousels/ListingCarousel.js
+++ b/stories/ag/Carousels/ListingCarousel.js
@@ -191,7 +191,7 @@ const listingProps = {
     },
   ],
   favoriteButton: {
-    onClick: action('click')('favorite toggle'),
+    onClick: (listing, value) => action('click')('favorite toggled to ', value),
     children: '♥',
   },
   banner: '$ Coupon',

--- a/stories/ag/Listings/MobileMapListing.js
+++ b/stories/ag/Listings/MobileMapListing.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { action } from '@storybook/addon-actions'
 import { MobileMapListing, SingleFamilyMobileMapListing } from 'react-ui-ag/src'
+import { boolean } from '@storybook/addon-knobs'
 
 const baseListing = {
   bedrooms: '1-3 Beds',
@@ -39,7 +40,7 @@ const props = {
   listing: baseListing,
   onClick: () => action('click')('listing cell click'),
   favoriteButton: {
-    onClick: () => action('click')('favorite toggle action'),
+    onClick: (listing, value) => action('click')('favorite toggled to ', value),
     children: '♥',
   },
   photos: {
@@ -78,10 +79,12 @@ const singleFamilyProps = {
   },
 }
 
-export const ExampleMobileMapListing = (
-  <MobileMapListing {...props} ctaButtons={ctaButtons} />
-)
+export const ExampleMobileMapListing = () => {
+  const isActive = boolean('isActive', true)
+  return <MobileMapListing {...props} ctaButtons={ctaButtons} isActive={isActive} />
+}
 
-export const ExampleSingleFamily = (
-  <SingleFamilyMobileMapListing {...singleFamilyProps} />
-)
+export const ExampleSingleFamily = () => {
+  const isActive = boolean('isActive', true)
+  return <SingleFamilyMobileMapListing {...singleFamilyProps} isActive={isActive} />
+}

--- a/stories/ag/index.js
+++ b/stories/ag/index.js
@@ -55,8 +55,8 @@ smallStories('Filters / PriceFilterCard / small', module)
   .add('Price Filter', () => InlinePriceFilterCard)
 
 smallStories('Listings', module)
-  .add('Mobile Map Listing', () => ExampleMobileMapListing)
-  .add('Single Family Mobile Map Listing', () => ExampleSingleFamily)
+  .add('Mobile Map Listing', ExampleMobileMapListing)
+  .add('Single Family Mobile Map Listing', ExampleSingleFamily)
 
 smallStories('Carousels', module)
   .add('Listing Carousel', () => DefaultListingCarousel)

--- a/stories/core/ListingCell.js
+++ b/stories/core/ListingCell.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import themed from 'react-themed'
 import { text, select, boolean } from '@storybook/addon-knobs'
 import { action } from '@storybook/addon-actions'
-import { ListingCell, ListingComponents } from 'react-ui-core/src'
+import { ListingCell, ListingComponents, Button } from 'react-ui-core/src'
 
 const baseListing = {
   bedrooms: '1-3 Bedrooms',
@@ -84,13 +84,14 @@ const SideBySideListingCell = ({ theme }) => {
   }
 
   return (
-    <ListingCell listing={listing} onClick={() => action('click')('click')}>
+    <ListingCell listing={listing} onClick={() => action('click')('card click')}>
       <div className={theme.SideBySideListingCell_BedBath}>
         <ListingComponents.Bedroom />
         <ListingComponents.Bathroom />
       </div>
       <ListingComponents.Ratings {...sideBySideRatingProps} />
       {listing.hasCoupon && <div>Coupon!</div>}
+      <Button onClick={() => action('click')('button click')}>Click me!</Button>
       <ListingComponents.Photos server="https://image.rent.com/" dimensions="400-200" showNav />
     </ListingCell>
   )

--- a/stories/theme/ag/small/MobileMapListing.css
+++ b/stories/theme/ag/small/MobileMapListing.css
@@ -173,3 +173,8 @@
 .MobileMapListing_BedsAndCta > Div {
   margin-top: 2px;
 }
+
+.MobileMapListing-inactive :global(.image-gallery-right-nav),
+.MobileMapListing-inactive :global(.image-gallery-left-nav) {
+  display: none;
+}


### PR DESCRIPTION
affects: @rentpath/react-ui-ag, @rentpath/react-ui-core

[Story](rentpath.leankit.com/card/615319754)

* change prioritizeCardClick to isActive
* add active/inactive classname based on isActive
* mobile map cta buttons no longer show with no text provided
* added inactive prop to ToggleButton
* pass !isActive to inactive in ToggleButton for favorite for mobile map listing
* added separate favorite toggle button handler to pass toggle value through

P.S. Having a strange hanger-on publish commit, im just going to let that one go along for the ride, don't mind those changes.