### PR TITLE
fix(Hybrid Map): allow isFavorited to be passed and used by MobileMap Listing

### DIFF
--- a/packages/react-ui-ag/src/Listings/MobileMapListing.js
+++ b/packages/react-ui-ag/src/Listings/MobileMapListing.js
@@ -112,11 +112,12 @@ export default class MobileMapListing extends PureComponent {
   }
 
   renderFavoriteButton() {
-    const { theme, favoriteButton, isActive } = this.props
+    const { theme, favoriteButton, isActive, listing } = this.props
     const { className } = favoriteButton
     return (
       <ToggleButton
         {...favoriteButton}
+        value={listing.isFavorited}
         className={classnames(
           theme.MobileMapListing_FavoriteButton,
           className,

--- a/packages/react-ui-ag/src/Listings/SingleFamilyMobileMapListing.js
+++ b/packages/react-ui-ag/src/Listings/SingleFamilyMobileMapListing.js
@@ -89,11 +89,12 @@ export default class SingleFamilyMobileMapListing extends PureComponent {
   }
 
   renderFavoriteButton() {
-    const { theme, favoriteButton, isActive } = this.props
+    const { theme, favoriteButton, isActive, listing } = this.props
     const { className } = favoriteButton
     return (
       <ToggleButton
         {...favoriteButton}
+        value={listing.isFavorited}
         className={classnames(
           theme.MobileMapListing_FavoriteButton,
           className,

--- a/packages/react-ui-ag/src/Listings/__tests__/MobileMapListing-test.js
+++ b/packages/react-ui-ag/src/Listings/__tests__/MobileMapListing-test.js
@@ -201,4 +201,28 @@ describe('ag/Listing/MobileMapListing', () => {
     const wrapper = shallow(<MobileMapListing {...props} isActive />)
     expect(wrapper.hasClass('MobileMapListing-active')).toBeTruthy()
   })
+
+  it('sets the favorite button to favorited when the listing has isFavorited as true', () => {
+    const favoritedProps = {
+      ...props,
+      listing: {
+        ...props.listing,
+        isFavorited: true,
+      },
+    }
+    const wrapper = shallow(<MobileMapListing {...favoritedProps} />)
+    expect(wrapper.find(ToggleButton).prop('value')).toBeTruthy()
+  })
+
+  it('sets the favorite button to not favorited when the listing has isFavorited as false', () => {
+    const favoritedProps = {
+      ...props,
+      listing: {
+        ...props.listing,
+        isFavorited: false,
+      },
+    }
+    const wrapper = shallow(<MobileMapListing {...favoritedProps} />)
+    expect(wrapper.find(ToggleButton).prop('value')).toBeFalsy()
+  })
 })

--- a/packages/react-ui-ag/src/Listings/__tests__/SingleFamilyMobileMapListing-test.js
+++ b/packages/react-ui-ag/src/Listings/__tests__/SingleFamilyMobileMapListing-test.js
@@ -152,4 +152,28 @@ describe('ag/Listing/SingleFamilyMobileMapListing', () => {
     const wrapper = shallow(<SingleFamilyMobileMapListing {...props} isActive />)
     expect(wrapper.hasClass('MobileMapListing-active')).toBeTruthy()
   })
+
+  it('sets the favorite button to favorited when the listing has isFavorited as true', () => {
+    const favoritedProps = {
+      ...props,
+      listing: {
+        ...props.listing,
+        isFavorited: true,
+      },
+    }
+    const wrapper = shallow(<SingleFamilyMobileMapListing {...favoritedProps} />)
+    expect(wrapper.find(ToggleButton).prop('value')).toBeTruthy()
+  })
+
+  it('sets the favorite button to not favorited when the listing has isFavorited as false', () => {
+    const favoritedProps = {
+      ...props,
+      listing: {
+        ...props.listing,
+        isFavorited: false,
+      },
+    }
+    const wrapper = shallow(<SingleFamilyMobileMapListing {...favoritedProps} />)
+    expect(wrapper.find(ToggleButton).prop('value')).toBeFalsy()
+  })
 })

--- a/stories/ag/Carousels/ListingCarousel.js
+++ b/stories/ag/Carousels/ListingCarousel.js
@@ -61,6 +61,7 @@ const listings = [
         caption: null,
       },
     ],
+    isFavorited: true,
   },
   {
     bedrooms: '1-4 Bedrooms',
@@ -115,6 +116,7 @@ const listings = [
         caption: null,
       },
     ],
+    isFavorited: true,
   },
   {
     bedrooms: '3 Beds',

--- a/stories/ag/Listings/MobileMapListing.js
+++ b/stories/ag/Listings/MobileMapListing.js
@@ -81,10 +81,31 @@ const singleFamilyProps = {
 
 export const ExampleMobileMapListing = () => {
   const isActive = boolean('isActive', true)
-  return <MobileMapListing {...props} ctaButtons={ctaButtons} isActive={isActive} />
+  const listing = {
+    ...baseListing,
+    isFavorited: boolean('listing.isFavorited', false),
+  }
+  return (
+    <MobileMapListing
+      {...props}
+      listing={listing}
+      ctaButtons={ctaButtons}
+      isActive={isActive}
+    />
+  )
 }
 
 export const ExampleSingleFamily = () => {
   const isActive = boolean('isActive', true)
-  return <SingleFamilyMobileMapListing {...singleFamilyProps} isActive={isActive} />
+  const listing = {
+    ...baseListing,
+    isFavorited: boolean('listing.isFavorited', false),
+  }
+  return (
+    <SingleFamilyMobileMapListing
+      {...singleFamilyProps}
+      listing={listing}
+      isActive={isActive}
+    />
+  )
 }


### PR DESCRIPTION
affects: @rentpath/react-ui-ag

[Story](https://rentpath.leankit.com/card/613135571)

* set favorited value on load based on listing.isFavorited