### PR TITLE
577743353 Add allowUnselect flag to RadioGroup

### DIFF
--- a/packages/react-ui-core/src/Form/RadioGroup.js
+++ b/packages/react-ui-core/src/Form/RadioGroup.js
@@ -25,12 +25,15 @@ export default class RadioGroup extends Component {
       checked: PropTypes.bool,
       value: PropTypes.string,
     })),
+    allowUnselect: PropTypes.bool,
     onChange: PropTypes.func,
+    onUnselect: PropTypes.func,
   }
 
   static defaultProps = {
     theme: {},
     fields: [],
+    allowUnselect: false,
   }
 
   constructor(props) {
@@ -73,6 +76,16 @@ export default class RadioGroup extends Component {
     }
   }
 
+  handleClick = event => {
+    // Check if value was already selected, should we unselect it?
+    if (this.props.allowUnselect && this.state.value === event.target.value) {
+      this.setState({ value: null })
+      if (this.props.onUnselect) {
+        this.props.onUnselect(event)
+      }
+    }
+  }
+
   renderRadioButton(index, fieldProps) {
     const props = pick(this.props, ['name', 'hideInputElement', 'orientation'])
 
@@ -82,6 +95,7 @@ export default class RadioGroup extends Component {
         key={`${this.id}-${index}`}
         checked={this.state.value === fieldProps.value}
         onChange={this.handleValueChange}
+        onClick={this.handleClick}
         {...omit(fieldProps, 'checked')}
         {...props}
       />
@@ -96,6 +110,8 @@ export default class RadioGroup extends Component {
       fields,
       hideInputElement,
       onChange,
+      allowUnselect,
+      onUnselect,
       ...props
     } = this.props
 

--- a/packages/react-ui-core/src/Form/__tests__/RadioGroup-test.js
+++ b/packages/react-ui-core/src/Form/__tests__/RadioGroup-test.js
@@ -156,4 +156,52 @@ describe('Form/RadioGroup', () => {
     })
     expect(wrapper.find(RadioButton).first().key()).toEqual(initialKey)
   })
+
+  it('unselects the radio button when using allowUnselect', () => {
+    const spyOnChange = jest.fn()
+    const spyOnUnselect = jest.fn()
+    const props = {
+      name: 'fooRadioGroup',
+      fields: [
+        { label: 'One', checked: false, value: 'One' },
+        { label: 'Two', checked: true, value: 'Two' },
+      ],
+      theme,
+      onChange: spyOnChange,
+      onUnselect: spyOnUnselect,
+      allowUnselect: true,
+    }
+    const wrapper = mount(<RadioGroup {...props} />)
+    expect(wrapper.state('value')).toEqual('Two')
+    wrapper.find('input[value="Two"]').simulate('click')
+    expect(wrapper.state('value')).toEqual(null)
+    expect(wrapper.find('input[value="Two"]').props()).not.toHaveProperty('checked', true)
+    expect(wrapper.find('input[value="One"]').props()).not.toHaveProperty('checked', true)
+    expect(spyOnChange).not.toBeCalled()
+    expect(spyOnUnselect).toBeCalled()
+  })
+
+  it('does not unselect the radio button when allowUnselect is false', () => {
+    const spyOnChange = jest.fn()
+    const spyOnUnselect = jest.fn()
+    const props = {
+      name: 'fooRadioGroup',
+      fields: [
+        { label: 'One', checked: false, value: 'One' },
+        { label: 'Two', checked: true, value: 'Two' },
+      ],
+      theme,
+      onChange: spyOnChange,
+      onUnselect: spyOnUnselect,
+      allowUnselect: false,
+    }
+    const wrapper = mount(<RadioGroup {...props} />)
+    expect(wrapper.state('value')).toEqual('Two')
+    wrapper.find('input[value="Two"]').simulate('click')
+    expect(wrapper.state('value')).toEqual('Two')
+    expect(wrapper.find('input[value="Two"]').props()).toHaveProperty('checked', true)
+    expect(wrapper.find('input[value="One"]').props()).not.toHaveProperty('checked', true)
+    expect(spyOnChange).not.toBeCalled()
+    expect(spyOnUnselect).not.toBeCalled()
+  })
 })

--- a/stories/core/RadioGroup.js
+++ b/stories/core/RadioGroup.js
@@ -39,6 +39,21 @@ export const VerticalRadioGroup = (
   />
 )
 
+export const UnselectRadioGroup = (
+  <RadioGroup
+    name={'radio-group-4'}
+    orientation="vertical"
+    hideInputElement
+    fields={[
+      { label: 'Uno', checked: true, value: 'Uno' },
+      { label: 'Dos', checked: false, value: 'Dos' },
+    ]}
+    onChange={event => action('change')(event.target.value)}
+    allowUnselect
+    onUnselect={event => action('unselect')(event.target.value)}
+  />
+)
+
 export const ImageButtonsRadioGroup = (
   <RadioGroup
     name="animals"

--- a/stories/core/index.js
+++ b/stories/core/index.js
@@ -66,6 +66,7 @@ import {
   DefaultRadioGroup,
   ButtonRadioGroup,
   VerticalRadioGroup,
+  UnselectRadioGroup,
   ImageButtonsRadioGroup,
 } from './RadioGroup'
 
@@ -207,6 +208,7 @@ coreStories('RadioGroup', module)
   .add('Radiogroup', () => DefaultRadioGroup)
   .add('Vertical Radiogroup as Buttons', () => ButtonRadioGroup)
   .add('Vertical Radiogroup', () => VerticalRadioGroup)
+  .add('Unselect Radiogroup', () => UnselectRadioGroup)
   .add('Image Buttons in RadioGroup', () => ImageButtonsRadioGroup)
 
 coreStories('RangeSlider', module)


### PR DESCRIPTION
LeanKit: [rent-js desktop more filters](https://rentpath.leankit.com/card/577743353)

To handle a use case when we have a group of radio buttons, but user also needs ability to unselect all the buttons:
- Added `allowUnselect` prop to the RadioGroup component
- Added `onUnselect` callback, because setting state to unselect the radio group cannot accurately trigger the `onChange` event. So if you are using allowUnselect it is on you to listen for both events if necessary.
- Added demo `Unselect RadioGroup` to the storybook
- Add unit tests for RadioGroup component
  - Verify button can be clicked to unselect when using allowUnselect
  - Verify button cannot be clicked to unselect when not using allowUnselect
  - Verify onUnselect / onChange event handlers are called as appropritate
