### PR TITLE
feat(Hybrid Map): Enable Lazyloading in MobileMapListing 

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "license": "MIT",
   "scripts": {
+    "build:watch": "yarn run build -- --watch",
     "build": "lerna run build",
     "build-storybook": "build-storybook -c .storybook -s .storybook/dist -o build",
     "clean": "lerna run clean --yes",

--- a/packages/react-ui-ag/src/Carousels/__tests__/ListingCarousel-test.js
+++ b/packages/react-ui-ag/src/Carousels/__tests__/ListingCarousel-test.js
@@ -176,13 +176,7 @@ const listingProps = {
     dimensions: '280-120',
     disableSwipe: true,
   },
-  /* eslint-disable max-len */
-  // TODO
-  // gaa: This needs to be false because jsdom is providing a mocked DOM and react-lazyload
-  // manipulates the DOM so it crashes when attempting to create placeholders
-  // I'll need to look into this further later to see if we can fix this.
   lazyLoad: false,
-  /* eslint-enable max-len */
 }
 
 describe('ListingCarousel', () => {

--- a/packages/react-ui-ag/src/Carousels/__tests__/ListingCarousel-test.js
+++ b/packages/react-ui-ag/src/Carousels/__tests__/ListingCarousel-test.js
@@ -176,6 +176,13 @@ const listingProps = {
     dimensions: '280-120',
     disableSwipe: true,
   },
+  /* eslint-disable max-len */
+  // TODO
+  // gaa: This needs to be false because jsdom is providing a mocked DOM and react-lazyload
+  // manipulates the DOM so it crashes when attempting to create placeholders
+  // I'll need to look into this further later to see if we can fix this.
+  lazyLoad: false,
+  /* eslint-enable max-len */
 }
 
 describe('ListingCarousel', () => {

--- a/packages/react-ui-ag/src/Listings/MobileMapListing.js
+++ b/packages/react-ui-ag/src/Listings/MobileMapListing.js
@@ -15,6 +15,13 @@ const buttonPropTypes = PropTypes.shape({
   valueLocation: PropTypes.string,
 })
 
+const REACT_LAZYLOAD_PROP_DEFAULTS = {
+  offset: [250, -100],
+  resize: true,
+  width: 280,
+  height: 120,
+}
+
 @themed(/^MobileMapListing/)
 export default class MobileMapListing extends Component {
   static propTypes = {
@@ -28,11 +35,16 @@ export default class MobileMapListing extends Component {
     propertyName: PropTypes.object,
     ctaButtons: PropTypes.arrayOf(buttonPropTypes),
     favoriteButton: buttonPropTypes,
+    lazyLoad: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.bool,
+    ]),
     isActive: PropTypes.bool,
   }
 
   static defaultProps = {
     isActive: true,
+    lazyLoad: true,
     theme: {},
     listing: {},
     ratings: {},
@@ -142,6 +154,30 @@ export default class MobileMapListing extends Component {
     )
   }
 
+  renderPhotoCarousel() {
+    const { theme, lazyLoad, photos } = this.props
+    const photoProps = {
+      showNav: true,
+      ...photos,
+    }
+
+    if (lazyLoad) {
+      photoProps.lazyLoad =
+        typeof lazyLoad === 'boolean'
+          ? REACT_LAZYLOAD_PROP_DEFAULTS
+          : lazyLoad
+    }
+
+    return (
+      <div className={theme.MobileMapListing_Top}>
+        <ListingComponents.Photos
+          {...photoProps}
+          className={theme.MobileMapListing_Photos}
+        />
+      </div>
+    )
+  }
+
   render() {
     const {
       theme,
@@ -154,6 +190,7 @@ export default class MobileMapListing extends Component {
       favoriteButton,
       propertyName,
       isActive,
+      lazyLoad,
       ...props
     } = this.props
 
@@ -176,13 +213,7 @@ export default class MobileMapListing extends Component {
             className={theme.MobileMapListing_Banner}
           />
         }
-        <div className={theme.MobileMapListing_Top}>
-          <ListingComponents.Photos
-            showNav
-            {...photos}
-            className={theme.MobileMapListing_Photos}
-          />
-        </div>
+        {this.renderPhotoCarousel()}
         <div className={theme.MobileMapListing_Bottom}>
           <div className={theme.MobileMapListing_Info}>
             <ListingComponents.Price />

--- a/packages/react-ui-ag/src/Listings/MobileMapListing.js
+++ b/packages/react-ui-ag/src/Listings/MobileMapListing.js
@@ -155,14 +155,11 @@ export default class MobileMapListing extends Component {
   }
 
   renderPhotoCarousel() {
-    const { theme, lazyLoad, photos } = this.props
-    const photoProps = {
-      showNav: true,
-      ...photos,
-    }
+    const { theme, photos } = this.props
+    let { lazyLoad } = this.props
 
-    if (lazyLoad) {
-      photoProps.lazyLoad =
+    if (lazyLoad && typeof lazyLoad === 'boolean') {
+      lazyLoad =
         typeof lazyLoad === 'boolean'
           ? REACT_LAZYLOAD_PROP_DEFAULTS
           : lazyLoad
@@ -171,7 +168,9 @@ export default class MobileMapListing extends Component {
     return (
       <div className={theme.MobileMapListing_Top}>
         <ListingComponents.Photos
-          {...photoProps}
+          showNav
+          {...photos}
+          lazyLoad={lazyLoad}
           className={theme.MobileMapListing_Photos}
         />
       </div>

--- a/packages/react-ui-ag/src/Listings/SingleFamilyMobileMapListing.js
+++ b/packages/react-ui-ag/src/Listings/SingleFamilyMobileMapListing.js
@@ -13,8 +13,14 @@ const buttonPropTypes = PropTypes.shape({
   className: PropTypes.string,
 })
 
-@themed(/^MobileMapListing/)
+const REACT_LAZYLOAD_PROP_DEFAULTS = {
+  offset: [250, -100],
+  resize: true,
+  width: 280,
+  height: 120,
+}
 
+@themed(/^MobileMapListing/)
 export default class SingleFamilyMobileMapListing extends Component {
   static propTypes = {
     index: PropTypes.number,
@@ -25,6 +31,10 @@ export default class SingleFamilyMobileMapListing extends Component {
     photos: PropTypes.object,
     ctaButton: buttonPropTypes,
     favoriteButton: buttonPropTypes,
+    lazyLoad: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.object,
+    ]),
     isActive: PropTypes.bool,
   }
 
@@ -33,6 +43,7 @@ export default class SingleFamilyMobileMapListing extends Component {
     listing: {},
     ctaButton: {},
     isActive: true,
+    lazyLoad: true,
   }
 
   @autobind
@@ -112,6 +123,26 @@ export default class SingleFamilyMobileMapListing extends Component {
     )
   }
 
+  renderPhotoCarousel() {
+    const { theme, photos } = this.props
+    let { lazyLoad } = this.props
+
+    if (lazyLoad && typeof lazyLoad === 'boolean') {
+      lazyLoad = REACT_LAZYLOAD_PROP_DEFAULTS
+    }
+
+    return (
+      <div className={theme.MobileMapListing_Top}>
+        <ListingComponents.Photos
+          showNav
+          {...photos}
+          lazyLoad={lazyLoad}
+          className={theme.MobileMapListing_Photos}
+        />
+      </div>
+    )
+  }
+
   render() {
     const {
       theme,
@@ -122,6 +153,7 @@ export default class SingleFamilyMobileMapListing extends Component {
       ctaButton,
       favoriteButton,
       isActive,
+      lazyLoad,
       ...props
     } = this.props
 
@@ -144,13 +176,7 @@ export default class SingleFamilyMobileMapListing extends Component {
             className={theme.MobileMapListing_Banner}
           />
         }
-        <div className={theme.MobileMapListing_Top}>
-          <ListingComponents.Photos
-            showNav
-            {...props}
-            {...photos}
-          />
-        </div>
+        {this.renderPhotoCarousel()}
         <div className={theme.MobileMapListing_Bottom}>
           <div className={theme.MobileMapListing_Info}>
             <ListingComponents.Price />

--- a/packages/react-ui-ag/src/Listings/__tests__/MobileMapListing-test.js
+++ b/packages/react-ui-ag/src/Listings/__tests__/MobileMapListing-test.js
@@ -31,6 +31,10 @@ const baseListing = {
       path: '',
       caption: '',
     },
+    {
+      path: '',
+      caption: '',
+    },
   ],
 }
 
@@ -66,6 +70,7 @@ const props = {
     server: 'https://image.rent.com/',
     dimensions: '280-120',
   },
+  lazyLoad: false,
 }
 
 describe('ag/Listing/MobileMapListing', () => {

--- a/packages/react-ui-ag/src/Listings/__tests__/SingleFamilyMobileMapListing-test.js
+++ b/packages/react-ui-ag/src/Listings/__tests__/SingleFamilyMobileMapListing-test.js
@@ -24,8 +24,6 @@ const baseListing = {
 }
 
 const props = {
-  server: '',
-  dimensions: '280-120',
   listing: baseListing,
   theme,
   onClick: () => { },
@@ -47,6 +45,11 @@ const props = {
     children: '♥',
   },
   banner: '$ Coupon',
+  photos: {
+    server: 'https://image.rent.com/',
+    dimensions: '280-120',
+  },
+  lazyLoad: false,
 }
 
 describe('ag/Listing/SingleFamilyMobileMapListing', () => {
@@ -110,7 +113,10 @@ describe('ag/Listing/SingleFamilyMobileMapListing', () => {
       />
     )
 
-    wrapper.find('[data-tid="carousel-navigation-next"]').at(0).simulate('click')
+    wrapper
+      .find('[data-tid="carousel"]')
+      .find('[className="image-gallery-left-nav"]')
+      .simulate('click')
     expect(cardClick).not.toHaveBeenCalled()
   })
 

--- a/packages/react-ui-core/src/Carousel/PhotoCarousel.js
+++ b/packages/react-ui-core/src/Carousel/PhotoCarousel.js
@@ -42,7 +42,9 @@ export default class PhotoCarousel extends PureComponent {
     const props = typeof lazyLoad === 'object' ? lazyLoad : {}
 
     return (
-      <LazyLoad {...props}>
+      <LazyLoad
+        {...props}
+      >
         {this.renderCarousel()}
       </LazyLoad>
     )
@@ -65,6 +67,7 @@ export default class PhotoCarousel extends PureComponent {
       className,
       theme,
       items,
+      lazyLoad,
       ...rest
     } = this.props
 
@@ -73,6 +76,7 @@ export default class PhotoCarousel extends PureComponent {
         items={items}
         infinite
         renderItem={this.renderItem}
+        lazyLoad={!!lazyLoad}
         {...rest}
         className={classnames(
           theme.PhotoCarousel,

--- a/packages/react-ui-core/src/Carousel/__tests__/Carousel-test.js
+++ b/packages/react-ui-core/src/Carousel/__tests__/Carousel-test.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import { shallow, mount } from 'enzyme'
+import LazyLoad from 'react-lazyload'
 import theme from './mocks/theme'
 import ThemedCarousel from '../Carousel'
 import ThemedCarouselNavigation from '../CarouselNavigation'
@@ -43,6 +44,18 @@ describe('Carousel', () => {
       />
     )
     expect(wrapper.find('.TestItem')).toHaveLength(4)
+  })
+
+  it('lazyLoads images if required', () => {
+    const wrapper = shallow(
+      <Carousel
+        theme={theme}
+        items={items}
+        lazyLoad
+      />
+    )
+
+    expect(wrapper.find(<LazyLoad />)).toBeTruthy()
   })
 
   describe('slideToIndex', () => {

--- a/stories/ag/Carousels/ListingCarousel.js
+++ b/stories/ag/Carousels/ListingCarousel.js
@@ -222,6 +222,12 @@ const listingProps = {
     backgroundFillColor: '#9b9b9b',
     strokeWidth: '0',
   },
+  lazyLoad: {
+    offset: [250, -100],
+    resize: true,
+    width: 280,
+    height: 120,
+  },
 }
 
 const singleFamilyProps = {

--- a/stories/core/Carousel.js
+++ b/stories/core/Carousel.js
@@ -87,32 +87,40 @@ export const CarouselNavigation = (
   />
 )
 
+const photoProps = [
+  {
+    path: 'imgr/2576db62ffa153ebef00317a5c68a368/',
+    caption: 'test 1',
+  },
+  {
+    path: 'imgr/d56984e959a3feb1235f85ee202a0fc6/',
+    caption: null,
+  },
+  {
+    path: 'imgr/fd972eb03a0463c484580349ad5177b7/',
+    caption: null,
+  },
+  {
+    path: 'imgr/d9551cdeb8152c6ecafd96ccf0c9a5dc/',
+    caption: null,
+  },
+  {
+    path: 'imgr/d13b78bff171be4a68ff576e036251ab/',
+    caption: null,
+  },
+]
+
 export const PhotoCarouselExample = (
   <PhotoCarousel
-    items={[
-      {
-        path: 'imgr/2576db62ffa153ebef00317a5c68a368/',
-        caption: 'test 1',
-      },
-      {
-        path: 'imgr/d56984e959a3feb1235f85ee202a0fc6/',
-        caption: null,
-      },
-      {
-        path: 'imgr/fd972eb03a0463c484580349ad5177b7/',
-        caption: null,
-      },
-      {
-        path: 'imgr/d9551cdeb8152c6ecafd96ccf0c9a5dc/',
-        caption: null,
-      },
-      {
-        path: 'imgr/d13b78bff171be4a68ff576e036251ab/',
-        caption: null,
-      },
-    ]}
+    items={photoProps}
     server="https://image.rent.com/"
     dimensions="400-200"
+    lazyLoad={{
+      offset: 100,
+      resize: true,
+      height: 158,
+      width: 280,
+    }}
     showNav
   />
 )


### PR DESCRIPTION
affects: @rentpath/react-ui-ag, @rentpath/react-ui-core

Enabling react-image-gallery -lazy to render only 3 items for PhotoCarousel
Enabling react-lazyload to use placeholders for photos not needing rendering