### PR TITLE
fix(Desktop Hybrid Map): support selected class to ListItem, List, Menu, and DropdownMenu

### DIFF
--- a/packages/react-ui-core/src/List/List.js
+++ b/packages/react-ui-core/src/List/List.js
@@ -21,6 +21,7 @@ export default class List extends PureComponent {
     items: PropTypes.array,
     orientation: PropTypes.string,
     highlightIndex: PropTypes.number,
+    selectedIndex: PropTypes.number,
   }
 
   static defaultProps = {
@@ -61,6 +62,7 @@ export default class List extends PureComponent {
       listItem,
       orientation,
       highlightIndex,
+      selectedIndex,
       ...props
     } = this.props
 
@@ -78,6 +80,7 @@ export default class List extends PureComponent {
           <Item
             {...itemProps}
             highlight={highlightIndex === i}
+            selected={selectedIndex === i}
             key={this.itemId(i)}
             index={i}
             data-tid={`list-item-${i}`}

--- a/packages/react-ui-core/src/List/ListItem.js
+++ b/packages/react-ui-core/src/List/ListItem.js
@@ -23,6 +23,7 @@ export default class ListItem extends PureComponent {
     onClick: PropTypes.func,
     index: PropTypes.number,
     highlight: PropTypes.bool,
+    selected: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -45,6 +46,7 @@ export default class ListItem extends PureComponent {
       onMouseEnter,
       index,
       highlight,
+      selected,
       nodeType: NodeType,
       ...props
     } = this.props
@@ -54,7 +56,8 @@ export default class ListItem extends PureComponent {
         className={cn(
           theme.ListItem,
           className,
-          highlight && theme['ListItem-highlight']
+          highlight && theme['ListItem-highlight'],
+          selected && theme['ListItem-selected'],
         )}
         index={index}
         onMouseEnter={this.handleMouseEnter}

--- a/packages/react-ui-core/src/List/__tests__/List-test.js
+++ b/packages/react-ui-core/src/List/__tests__/List-test.js
@@ -88,12 +88,23 @@ describe('List', () => {
     })
 
     describe('highlightIndex', () => {
-      it('sets ListItem `activate` true when highlightIndex equals index', () => {
+      it('sets ListItem `highlight` true when highlightIndex equals index', () => {
         const highlightIndex = 1
         wrapper.setProps({ highlightIndex, items })
-        wrapper.find(ListItem).map((item, index) => { // eslint-disable-line
+        wrapper.find(ListItem).forEach((item, index) => {
           const active = index === highlightIndex
           expect(item.prop('highlight')).toEqual(active)
+        })
+      })
+    })
+
+    describe('selectedIndex', () => {
+      it('sets ListItem `selected` true when highlightIndex equals index', () => {
+        const selectedIndex = 1
+        wrapper.setProps({ selectedIndex, items })
+        wrapper.find(ListItem).forEach((item, index) => {
+          const active = index === selectedIndex
+          expect(item.prop('selected')).toEqual(active)
         })
       })
     })

--- a/packages/react-ui-core/src/List/__tests__/ListItem-test.js
+++ b/packages/react-ui-core/src/List/__tests__/ListItem-test.js
@@ -36,6 +36,17 @@ describe('ListItem', () => {
         expect(wrapper.prop('className')).not.toContain('ListItem-highlight')
       })
     })
+
+    describe('selected prop', () => {
+      it('adds a selected class when true', () => {
+        wrapper.setProps({ selected: true })
+        expect(wrapper.prop('className')).toContain('ListItem-selected')
+      })
+
+      it('does not add a selected class when undefined / false', () => {
+        expect(wrapper.prop('className')).not.toContain('ListItem-selected')
+      })
+    })
   })
 
   describe('onMouseEnter', () => {

--- a/packages/react-ui-core/src/List/__tests__/mocks/theme.js
+++ b/packages/react-ui-core/src/List/__tests__/mocks/theme.js
@@ -5,4 +5,5 @@ export default keyMirror([
   'List-horizontal',
   'ListItem',
   'ListItem-highlight',
+  'ListItem-selected',
 ])

--- a/packages/react-ui-core/src/Menu/DropdownMenu.js
+++ b/packages/react-ui-core/src/Menu/DropdownMenu.js
@@ -101,6 +101,7 @@ export default class DropdownMenu extends Component {
       >
         <MenuWrapper
           options={options}
+          selectedIndex={this.state.selectedIndex}
           onItemSelect={this.itemSelectionHandler}
         />
       </Dropdown>

--- a/packages/react-ui-core/src/Menu/Menu.js
+++ b/packages/react-ui-core/src/Menu/Menu.js
@@ -33,6 +33,7 @@ export default class Menu extends PureComponent {
       PropTypes.object,
     ]),
     highlightIndex: PropTypes.number,
+    selectedIndex: PropTypes.number,
   }
 
   static defaultProps = {
@@ -121,6 +122,7 @@ export default class Menu extends PureComponent {
       onItemMouseOver,
       className,
       onItemSelect,
+      selectedIndex,
       ...props
     } = this.props
 
@@ -133,6 +135,7 @@ export default class Menu extends PureComponent {
         )}
         items={this.items}
         highlightIndex={this.state.highlightIndex}
+        selectedIndex={selectedIndex}
         onClick={this.handleSelection}
         onMouseEnter={this.highlightOption}
         {...props}

--- a/packages/react-ui-core/src/Menu/__tests__/DropdownMenu-test.js
+++ b/packages/react-ui-core/src/Menu/__tests__/DropdownMenu-test.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { mount, shallow } from 'enzyme'
 import ThemedDropdownMenu from '../DropdownMenu'
 import Menu from '../Menu'
+import MenuWrapper from '../MenuWrapper'
 
 const DropdownMenu = ThemedDropdownMenu.WrappedComponent
 
@@ -78,5 +79,10 @@ describe('DropdownMenu', () => {
     expect(wrapper.state('selectedIndex')).toEqual(0)
     wrapper.setProps({ selectedValue: 'bar-value' })
     expect(wrapper.state('selectedIndex')).toEqual(1)
+  })
+
+  it('passes the selectedIndex to the Menu', () => {
+    const wrapper = shallow(<DropdownMenu {...props} selectedIndex={2} />)
+    expect(wrapper.find(MenuWrapper).prop('selectedIndex')).toEqual(2)
   })
 })

--- a/packages/react-ui-core/src/Menu/__tests__/Menu-test.js
+++ b/packages/react-ui-core/src/Menu/__tests__/Menu-test.js
@@ -153,6 +153,11 @@ describe('Menu', () => {
     })
   })
 
+  it('passes the selectedIndex prop to List', () => {
+    const wrapper = shallow(<Menu options={options} selectedIndex={2} />)
+    expect(wrapper.find(List).prop('selectedIndex')).toEqual(2)
+  })
+
   describe('with object options', () => {
     it('passes just the labels to List', () => {
       const wrapper = shallow(<Menu options={objectOptions} />)

--- a/stories/ag/GridView/GridViewHeader.js
+++ b/stories/ag/GridView/GridViewHeader.js
@@ -32,7 +32,7 @@ const ExampleGridViewHeaderComponent = ({ theme }) => (
         ],
         createAnchorText: anchorText => [
           <div key="sort-label" className={theme.GridViewHeader_SortLabel}>Sort By:</div>,
-          anchorText,
+          <div key="anchor-text" className={theme.GridViewHeader_AnchorText}>{anchorText}</div>,
           <div key="sort-chevron" className={theme.GridViewHeader_SortChevron}>⌄</div>,
         ],
         selectedValue: select(

--- a/stories/theme/ag/large/GridView/GridViewHeader.css
+++ b/stories/theme/ag/large/GridView/GridViewHeader.css
@@ -5,6 +5,8 @@
   background-color: #ffffff;
   height: 40px;
   padding-left: 10px;
+  color: #373737;
+  font-size: 12px;
 }
 
 .GridViewHeaderCard {
@@ -14,7 +16,6 @@
   background-color: #f7f7f7;
   justify-content: center;
   padding-top: 30px;
-  font-size: 12px;
 }
 
 .GridViewHeader_Counter {
@@ -32,7 +33,7 @@
 }
 
 .GridViewHeader .DropdownAnchor {
-  width: 225px;
+  min-width: 150px;
   border: 0;
   background-color: transparent;
   padding: 0;
@@ -41,6 +42,10 @@
   cursor: pointer;
   padding: 14px;
   position: relative;
+}
+
+.GridViewHeader_AnchorText {
+  padding-right: 15px;
 }
 
 .GridViewHeader .DropdownAnchor-expand {
@@ -72,11 +77,6 @@
   padding: 0 10px;
 }
 
-.GridViewHeader .ListItem:hover {
-  background-color: #5a5a5a;
-  color: #ffffff;
-}
-
 .GridViewHeader_SortChevron {
   font-size: 30px;
   position: absolute;
@@ -87,4 +87,14 @@
 
 .GridViewHeader .DropdownAnchor-expand .GridViewHeader_SortChevron {
   transform: rotate(180deg);
+}
+
+.GridViewHeader .ListItem-selected {
+  background: #5a5a5a;
+  color: #ffffff;
+}
+
+.GridViewHeader .ListItem-highlight {
+  background-color: #e6e7e8;
+  color: #373737;
 }


### PR DESCRIPTION
affects: @rentpath/react-ui-core

[Story](https://rentpath.leankit.com/card/628904109)
* add `selected` bool to `ListItem` that triggers CSS class
* add `selectedIndex` prop to `List`
* add `selectedIndex` prop to `Menu`
* pass `selectedIndex` prop from `DropdownMenu` to `Menu`
* added support for `ListItem-selected` to GridViewHeader CSS