### PR TITLE
fix(react-ui-ag): shouldComponentUpdate only cares about isActive

### DIFF
--- a/packages/react-ui-ag/src/Listings/MobileMapListing.js
+++ b/packages/react-ui-ag/src/Listings/MobileMapListing.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import themed from 'react-themed'
 import classnames from 'classnames'
 import autobind from 'autobind-decorator'
-import isEqual from 'lodash/isEqual'
 import get from 'lodash/get'
 import { Button, ToggleButton, ListingComponents, ListingCell } from '@rentpath/react-ui-core'
 import { Banner } from '../Banners'
@@ -51,10 +50,9 @@ export default class MobileMapListing extends Component {
     photos: {},
   }
 
-  @autobind
   shouldComponentUpdate(nextProps) {
-    return !isEqual(nextProps.listing, this.props.listing)
-      || this.props.isActive !== nextProps.isActive
+    return this.props.isActive !== nextProps.isActive ||
+      this.props.listing.id !== nextProps.listing.id
   }
 
   @autobind

--- a/packages/react-ui-ag/src/Listings/SingleFamilyMobileMapListing.js
+++ b/packages/react-ui-ag/src/Listings/SingleFamilyMobileMapListing.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import themed from 'react-themed'
 import classnames from 'classnames'
 import autobind from 'autobind-decorator'
-import isEqual from 'lodash/isEqual'
 import { Button, ToggleButton, ListingComponents, ListingCell } from '@rentpath/react-ui-core'
 import { Banner } from '../Banners'
 
@@ -46,10 +45,9 @@ export default class SingleFamilyMobileMapListing extends Component {
     lazyLoad: true,
   }
 
-  @autobind
   shouldComponentUpdate(nextProps) {
-    return !isEqual(nextProps.listing, this.props.listing)
-      || this.props.isActive !== nextProps.isActive
+    return this.props.isActive !== nextProps.isActive ||
+      this.props.listing.id !== nextProps.listing.id
   }
 
   @autobind

--- a/packages/react-ui-ag/src/Listings/__tests__/MobileMapListing-test.js
+++ b/packages/react-ui-ag/src/Listings/__tests__/MobileMapListing-test.js
@@ -213,8 +213,8 @@ describe('ag/Listing/MobileMapListing', () => {
   it('adds a rating placeholder if the listing prop has no rating attribute', () => {
     const wrapper = shallow(<MobileMapListing {...props} />)
     expect(wrapper.find('[data-tid="rating-placeholder"]')).toHaveLength(0)
-    wrapper.setProps({ listing: omit(baseListing, 'rating') })
-    expect(wrapper.find('[data-tid="rating-placeholder"]')).toHaveLength(1)
+    const noRatingsWrapper = shallow(<MobileMapListing {...props} listing={omit(baseListing, 'rating')} />)
+    expect(noRatingsWrapper.find('[data-tid="rating-placeholder"]')).toHaveLength(1)
   })
 
   it('sets the favorite button to favorited when the listing has isFavorited as true', () => {


### PR DESCRIPTION
affects: @rentpath/react-ui-ag

This was done to prevent useless re-renders of all `MobileMapListings` on every swipe of the listing carousel - see images below