### PR TITLE
feat(AutoSuggestField Menu): Fixes debounce issue and menu

### DIFF
--- a/packages/react-ui-core/src/Menu/Menu.js
+++ b/packages/react-ui-core/src/Menu/Menu.js
@@ -114,10 +114,10 @@ export default class Menu extends PureComponent {
   handleSelection() {
     const { onItemSelect } = this.props
 
-    const value = this.highlightedOption
+    const option = this.highlightedOption
 
-    if (onItemSelect && value && !value.disabled) {
-      onItemSelect(value, this.state.highlightIndex)
+    if (onItemSelect && option && !option.disabled) {
+      onItemSelect(option, this.state.highlightIndex)
     }
   }
 

--- a/packages/react-ui-core/src/Menu/Menu.js
+++ b/packages/react-ui-core/src/Menu/Menu.js
@@ -47,14 +47,15 @@ export default class Menu extends PureComponent {
   constructor(props) {
     super(props)
     this.state = {
-      highlightIndex: props.highlightIndex || 0,
-      indexedOptionIndex: props.highlightIndex || 0,
+      highlightIndex: -1,
+      indexedOptionIndex: -1,
       indexedOptions: this.generateIndexedOptions(),
     }
   }
 
   componentDidMount() {
     document.addEventListener('keydown', this.onKeyDown)
+    this.highlightIndexedOption(0)
   }
 
   componentWillReceiveProps(nextProps) {
@@ -65,7 +66,7 @@ export default class Menu extends PureComponent {
     if (this.props.options !== nextProps.options) {
       this.setState({
         indexedOptions: this.generateIndexedOptions(),
-      })
+      }, this.highlightIndexedOption(0))
     }
   }
 

--- a/packages/react-ui-core/src/Menu/Menu.js
+++ b/packages/react-ui-core/src/Menu/Menu.js
@@ -46,7 +46,6 @@ export default class Menu extends PureComponent {
 
   constructor(props) {
     super(props)
-
     this.state = {
       highlightIndex: props.highlightIndex || 0,
       indexedOptionIndex: props.highlightIndex || 0,
@@ -107,7 +106,7 @@ export default class Menu extends PureComponent {
     )
   }
 
-  get option() {
+  get highlightedOption() {
     return this.options[this.state.highlightIndex || 0]
   }
 
@@ -115,7 +114,7 @@ export default class Menu extends PureComponent {
   handleSelection() {
     const { onItemSelect } = this.props
 
-    const value = this.option
+    const value = this.highlightedOption
 
     if (onItemSelect && value && !value.disabled) {
       onItemSelect(value, this.state.highlightIndex)
@@ -130,7 +129,7 @@ export default class Menu extends PureComponent {
     this.setState({
       highlightIndex: index,
     }, () => {
-      if (onItemMouseOver) onItemMouseOver(this.option)
+      if (onItemMouseOver) onItemMouseOver(this.highlightedOption)
     })
   }
 
@@ -143,7 +142,7 @@ export default class Menu extends PureComponent {
       highlightIndex: this.state.indexedOptions[index].index,
       indexedOptionIndex: index,
     }, () => {
-      if (onItemMouseOver) onItemMouseOver(this.option
+      if (onItemMouseOver) onItemMouseOver(this.highlightedOption)
     })
   }
 

--- a/packages/react-ui-core/src/Menu/__tests__/Menu-test.js
+++ b/packages/react-ui-core/src/Menu/__tests__/Menu-test.js
@@ -183,9 +183,20 @@ describe('Menu', () => {
       wrapper.find('ListItem').at(1).simulate('mouseenter').simulate('click')
       expect(onItemSelect).toHaveBeenCalledWith(objectOptions[1], 1)
     })
+
+    it('passes objects that do not have label key to List', () => {
+      const optionsRandom = [
+        {
+          a: 'a',
+          b: 'b',
+        },
+      ]
+      const wrapper = shallow(<Menu options={optionsRandom} />)
+      expect(wrapper.find(List).prop('items')).toEqual(optionsRandom)
+    })
   })
 
-  describe('with object with disabled attribute', () => {
+  describe('with object with disabled key', () => {
     it('should not perform on click functionality', () => {
       const testObject = {
         value: -1,

--- a/packages/react-ui-core/src/Menu/__tests__/Menu-test.js
+++ b/packages/react-ui-core/src/Menu/__tests__/Menu-test.js
@@ -185,7 +185,7 @@ describe('Menu', () => {
     })
   })
 
-  describe('with object with no value attribute', () => {
+  describe('with object with disabled attribute', () => {
     it('should not perform on click functionality', () => {
       const testObject = {
         value: -1,

--- a/packages/react-ui-core/src/Menu/__tests__/Menu-test.js
+++ b/packages/react-ui-core/src/Menu/__tests__/Menu-test.js
@@ -132,22 +132,10 @@ describe('Menu', () => {
   })
 
   it('should perform on mouseover functionality ', () => {
-    const testObject = {
-      value: -1,
-    }
-
-    const { wrapper } = setup({
-      theme,
-      options,
-      onItemMouseOver: value => {
-        testObject.value = value
-      },
-    })
-
-    expect(testObject.value).toEqual(-1)
-    const listItemTwo = wrapper.find('ListItem').at(2)
-    listItemTwo.simulate('mouseenter')
-    expect(testObject.value).toEqual(3)
+    const onItemSelect = jest.fn()
+    const wrapper = mount(<Menu options={options} onItemSelect={onItemSelect} />)
+    wrapper.find('ListItem').at(1).simulate('mouseenter').simulate('click')
+    expect(onItemSelect).toHaveBeenCalledWith(options[1], 1)
   })
 
   describe('highlightOption', () => {
@@ -197,6 +185,13 @@ describe('Menu', () => {
   })
 
   describe('with object with disabled key', () => {
+    it('should not highlight disabed option indices by default', () => {
+      const wrapper = shallow(<Menu options={[{ disabled: true }, { disabled: true }]} />)
+      const wrapperInst = wrapper.instance()
+      wrapperInst.highlightOption(20)
+      expect(wrapperInst.state.highlightIndex).toEqual(-1)
+    })
+
     it('should not perform on click functionality', () => {
       const testObject = {
         value: -1,

--- a/stories/core/Menu.js
+++ b/stories/core/Menu.js
@@ -27,7 +27,7 @@ const options = [
 
 export const DefaultMenu = (
   <Menu
-    options={[<div>1</div>, 2, 3]}
+    options={[1, 2, 3]}
   />
 )
 

--- a/stories/core/Menu.js
+++ b/stories/core/Menu.js
@@ -48,7 +48,7 @@ export const MenuOnSelectionHover = (
 
 export const MenuWithLabel = (
   <Menu
-    options={['Option1', { label: 'Unclickable Label', disabled: true }, 'Option3', { label: 'Unclickable Label 2', disabled: true }]}
+    options={['Option1', { label: 'Unclickable Label', disabled: true, value: 'Disabled Option1' }, 'Option3', { label: 'Unclickable Label 2', disabled: true, value: 'Disabled Option2' }]}
     onItemSelect={action('selected')}
     nodeType="section"
   />

--- a/stories/core/index.js
+++ b/stories/core/index.js
@@ -200,7 +200,7 @@ coreStories('Menu', module)
   .add('On Keyboard Selection', () => MenuOnSelection)
   .add('On Selection hover', () => MenuOnSelectionHover)
   .add('DropdownMenu', () => DefaultDropdownMenu)
-  .add('MenuWithLabel', () => MenuWithLabel)
+  .add('Menu with Disabled options', () => MenuWithLabel)
 
 coreStories('Modal', module)
   .add('Modal', () => DefaultModal)


### PR DESCRIPTION
affects: @rentpath/react-ui-core

[Card](https://rentpath.leankit.com/card/634890555)
- Added ability to include non-clickable options in suggestions
- Added tests
- Options are disabled by adding 'disabled:true' attribute to option object