### PR TITLE
634980824 Prevent modal from closing after dragging mouse outside

### DIFF
--- a/packages/react-ui-core/src/Modal/Overlay.js
+++ b/packages/react-ui-core/src/Modal/Overlay.js
@@ -10,6 +10,8 @@ import themed from 'react-themed'
 export default class Overlay extends PureComponent {
   static propTypes = {
     className: PropTypes.string,
+    onMouseDown: PropTypes.func,
+    onMouseUp: PropTypes.func,
     onClick: PropTypes.func,
     theme: PropTypes.object,
     children: PropTypes.node,
@@ -23,11 +25,39 @@ export default class Overlay extends PureComponent {
   constructor(props) {
     super(props)
     this.handleClick = this.handleClick.bind(this)
+    this.handleMouseDown = this.handleMouseDown.bind(this)
+    this.handleMouseUp = this.handleMouseUp.bind(this)
+  }
+
+  handleMouseDown(e) {
+    // Verify that the click started on the overlay
+    this.clickedOutside = (e.target === this.overlay)
+
+    if (this.props.onMouseDown) {
+      this.props.onMouseDown(e)
+    }
+  }
+
+  handleMouseUp(e) {
+    // Verify that the click ended on the overlay
+    if (e.target !== this.overlay) {
+      this.clickedOutside = false
+    }
+
+    if (this.props.onMouseUp) {
+      this.props.onMouseUp(e)
+    }
   }
 
   handleClick(e) {
+    // If the click did not start and end on the overlay do not register click
+    if (!this.clickedOutside) {
+      return
+    }
+    this.clickedOutside = null
+
     if (this.props.onClick && e.target === this.overlay) {
-      this.props.onClick()
+      this.props.onClick(e)
     }
   }
 
@@ -38,6 +68,8 @@ export default class Overlay extends PureComponent {
       <div
         ref={node => { this.overlay = node }}
         role="presentation"
+        onMouseDown={this.handleMouseDown}
+        onMouseUp={this.handleMouseUp}
         onClick={this.handleClick}
         className={classnames(
           className,

--- a/packages/react-ui-core/src/Modal/__tests__/Overlay-test.js
+++ b/packages/react-ui-core/src/Modal/__tests__/Overlay-test.js
@@ -25,35 +25,79 @@ describe('Modal/Overlay', () => {
 
   describe('onClick', () => {
     let wrapper
+    let onMouseDown
+    let onMouseUp
     let onClick
     let node
+    let child
 
     beforeEach(() => {
+      onMouseDown = jest.fn()
+      onMouseUp = jest.fn()
       onClick = jest.fn()
       wrapper = shallow(
-        <Overlay onClick={onClick}>
+        <Overlay
+          onClick={onClick}
+          onMouseDown={onMouseDown}
+          onMouseUp={onMouseUp}
+        >
           <div id="child" />
         </Overlay>,
       )
 
       node = wrapper.first()
+      child = wrapper.find('#child')
       wrapper.instance().overlay = node
     })
 
-    it('invokes when `onClick` and node clicked is root', () => {
-      wrapper.find('div').first().simulate('click', { target: node })
+    it('invokes when overlay is clicked and there is a callback', () => {
+      node.simulate('mouseDown', { target: node })
+      node.simulate('mouseUp', { target: node })
+      node.simulate('click', { target: node })
       expect(onClick).toBeCalled()
+      expect(onMouseDown).toBeCalled()
+      expect(onMouseUp).toBeCalled()
     })
 
-    it('does not invoke when no `onClick` prop', () => {
-      wrapper.setProps({ onClick: undefined })
-      wrapper.find('div').first().simulate('click', { target: node })
+    it('does not invoke when overlay is clicked but there is no callback', () => {
+      wrapper.setProps({
+        onClick: undefined,
+        onMouseDown: undefined,
+        onMouseUp: undefined,
+      })
+      node.simulate('mouseDown', { target: node })
+      node.simulate('mouseUp', { target: node })
+      node.simulate('click', { target: node })
       expect(onClick).not.toBeCalled()
+      expect(onMouseDown).not.toBeCalled()
+      expect(onMouseUp).not.toBeCalled()
     })
 
-    it('does not invoke when target clicked in not the root node', () => {
-      wrapper.find('#child').first().simulate('click', { target: node })
+    it('does not invoke when child is clicked', () => {
+      node.simulate('mouseDown', { target: child })
+      node.simulate('mouseUp', { target: child })
+      node.simulate('click', { target: child })
       expect(onClick).not.toBeCalled()
+      expect(onMouseDown).toBeCalled()
+      expect(onMouseUp).toBeCalled()
+    })
+
+    it('does not invoke when child clicked then dragged into overlay', () => {
+      node.simulate('mouseDown', { target: child })
+      node.simulate('mouseUp', { target: node })
+      node.simulate('click', { target: node })
+      expect(onClick).not.toBeCalled()
+      expect(onMouseDown).toBeCalled()
+      expect(onMouseUp).toBeCalled()
+    })
+
+    it('does not invoke when overlay clicked then dragged into child', () => {
+      node.simulate('mouseDown', { target: node })
+      node.simulate('mouseUp', { target: child })
+      node.simulate('click', { target: child })
+      expect(onClick).not.toBeCalled()
+      expect(onMouseDown).toBeCalled()
+      expect(onMouseUp).toBeCalled()
     })
   })
 })


### PR DESCRIPTION
LeanKit card (rent-js): [Prevent modal closing after dragging mouse](https://rentpath.leankit.com/card/634980824)

In some cases, especially when the modal contains a draggable control such as a price slider, the user might click inside the modal, hold the button to drag, then release the button outside of the modal. Currently this gets registered as a click on the overlay, and the modal closes, which is not what the user intended.

I examined some third-party modal react components and copied a technique for verifying the click on the overlay actually started and ended on the overlay.

Changes:
* Adds event handlers to the Overlay component to prevent triggering the onClick handler in cases where the overlay wasn't intentionally clicked.
* Modify unit tests that broke because of these changes
* Add new unit tests to simulate new use cases

How to test:
* View a modal.
* Move mouse cursor outside the modal, click the mouse button.
  - Verify that the close modal action occurs.
* Move mouse cursor into the modal, press and hold the mouse button, move the mouse cursor outside the modal, release the mouse button.
  - Verify the close modal action does not occur.
* Move mouse cursor outside the modal, press and hold the mouse button, move the mouse cursor inside the modal, release the mouse button.
  - Verify the close modal action does not occur.
* Move mouse cursor inside the modal, click the mouse button.
  - Verify the close modal action does not occur.