### PR TITLE
fix(AutoSuggestField): autoSuggestField changed to pass 'value' prop …

### DIFF
--- a/packages/react-ui-core/src/AutoSuggestField/AutoSuggestField.js
+++ b/packages/react-ui-core/src/AutoSuggestField/AutoSuggestField.js
@@ -81,6 +81,14 @@ export default class AutoSuggestField extends Component {
     document.addEventListener('keydown', this.onKeyDown)
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (!(this.props.value === nextProps.value)) {
+      this.setState({
+        value: nextProps.value,
+      })
+    }
+  }
+
   componentWillUnmount() {
     document.removeEventListener('keydown', this.onKeyDown)
   }

--- a/packages/react-ui-core/src/AutoSuggestField/__tests__/AutoSuggestField-test.js
+++ b/packages/react-ui-core/src/AutoSuggestField/__tests__/AutoSuggestField-test.js
@@ -117,6 +117,15 @@ describe('AutoSuggestField', () => {
     expect(onSubmit.mock.calls).toHaveLength(1)
   })
 
+  it('should update the value state to the prop when the prop changes', () => {
+    const { wrapper } = setup({
+      value: 'foo',
+    })
+    expect(wrapper.state('value')).toEqual('foo')
+    wrapper.setProps({ value: 'bar' })
+    expect(wrapper.state('value')).toEqual('bar')
+  })
+
   describe('clearButton', () => {
     const onAfterClear = jest.fn()
     const onVisibilityChange = jest.fn()

--- a/packages/react-ui-core/src/Dropdown/Dropdown.js
+++ b/packages/react-ui-core/src/Dropdown/Dropdown.js
@@ -70,6 +70,7 @@ export default class Dropdown extends Component {
   handleDocumentClick(event) {
     if (this.state.visible && !this.dropdown.contains(event.target)) {
       this.setState({ visible: false })
+      this.props.onVisibilityChange(false)
     }
   }
 

--- a/packages/react-ui-core/src/Dropdown/__tests__/Dropdown-test.js
+++ b/packages/react-ui-core/src/Dropdown/__tests__/Dropdown-test.js
@@ -84,6 +84,13 @@ describe('Dropdown', () => {
     expect(wrapper.state('visible')).toEqual(false)
   })
 
+  it('should call onVisibilityChange prop on outside click', () => {
+    const onVisibilityChange = jest.fn()
+    setup({ visible: true, onVisibilityChange })
+    map.click({ target: document.createElement('div') })
+    expect(onVisibilityChange.mock.calls).toHaveLength(1)
+  })
+
   it('passes label to default anchor', () => {
     const text = 'test'
     const wrapper = mount(


### PR DESCRIPTION
…to the state when it is updated

affects: @rentpath/react-ui-core

[Card](https://rentpath.leankit.com/card/638551669)
- AutoSuggestField changed to pass 'value' prop to the state when it is updated
- Added a componentWillRecieveProps to update 'value' in state when the prop changes
- Modifed dropdown to call onvisibilitychange on handleDocumentClick

Fixes Bugs
- react-ui-core autosuggestfield: Value prop is not passed to state on update
- react-ui-core dropdown: onvisibilitychange is not called on handleDocumentClick