### PR TITLE
fix(Menu): pass properties (other than label) to Menu ListItems

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,9 @@
   "extends": "@rentpath/eslint-config-rentpath",
   "parser": "babel-eslint",
   "rules": {
-    "global-require": 0
+    "global-require": 0,
+    "jest/no-disabled-tests": "error",
+    "jest/no-focused-tests": "error",
   },
   "plugins": [
     "react",

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ packages/**/package-lock.json
 coverage
 build
 artifacts
+.idea

--- a/packages/react-ui-core/src/Button/__tests__/ToggleButton-test.js
+++ b/packages/react-ui-core/src/Button/__tests__/ToggleButton-test.js
@@ -72,7 +72,7 @@ describe('ToggleButton', () => {
     expect(onClick.mock.calls[2][0]).toEqual(true)
   })
 
-  it.only('does not toggle when inactive is true', () => {
+  it('does not toggle when inactive is true', () => {
     const props = {
       theme,
       className: theme.ToggleButton,

--- a/packages/react-ui-core/src/List/__tests__/List-test.js
+++ b/packages/react-ui-core/src/List/__tests__/List-test.js
@@ -1,11 +1,38 @@
 import React from 'react'
 import { shallow, mount } from 'enzyme'
+import renderer from 'react-test-renderer'
 import theme from './mocks/theme'
 import ThemedList from '../List'
 import ListItem from '../ListItem'
 
 const List = ThemedList.WrappedComponent
 const items = [1, 2, 3]
+const menuItems = [
+  {
+    label: 'one',
+    value: 1,
+    test_attr: '2',
+  },
+  {
+    label: 'two',
+    value: 2,
+    test_attr: '2',
+  },
+]
+const labellessItems = [
+  {
+    value: 1,
+    test_attr: '2',
+  },
+  {
+    value: 2,
+    test_attr: '2',
+  },
+]
+
+const functionItems = [
+  () => (<div>foo</div>),
+]
 
 describe('List', () => {
   describe('mount', () => {
@@ -25,6 +52,31 @@ describe('List', () => {
         />
       )
       expect(wrapper.find('ListItem').at(0).prop('nodeType')).toEqual('span')
+    })
+
+    it('passes through object props', () => {
+      const snap = renderer
+        .create(<List items={menuItems} />)
+        .toJSON()
+      expect(snap).toMatchSnapshot()
+    })
+
+    it('handles labelless items', () => {
+      const errorFunc = global.console.error
+      global.console.error = jest.fn()
+      const snap = renderer
+        .create(<List items={labellessItems} />)
+        .toJSON()
+      expect(snap).toMatchSnapshot()
+      expect(console.error).toBeCalled() // eslint-disable-line no-console
+      console.error = errorFunc // eslint-disable-line no-console
+    })
+
+    it('handles function items', () => {
+      const snap = renderer
+        .create(<List items={functionItems} />)
+        .toJSON()
+      expect(snap).toMatchSnapshot()
     })
 
     it('accepts custom node type', () => {

--- a/packages/react-ui-core/src/List/__tests__/__snapshots__/List-test.js.snap
+++ b/packages/react-ui-core/src/List/__tests__/__snapshots__/List-test.js.snap
@@ -1,0 +1,68 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`List mount handles function items 1`] = `
+<ul
+  className=""
+>
+  <li
+    className=""
+    data-tid="list-item-0"
+    index={0}
+    onMouseEnter={[Function]}
+  >
+    <div>
+      foo
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`List mount handles labelless items 1`] = `
+<ul
+  className=""
+>
+  <li
+    className=""
+    data-tid="list-item-0"
+    index={0}
+    onMouseEnter={[Function]}
+    test_attr="2"
+    value={1}
+  />
+  <li
+    className=""
+    data-tid="list-item-1"
+    index={1}
+    onMouseEnter={[Function]}
+    test_attr="2"
+    value={2}
+  />
+</ul>
+`;
+
+exports[`List mount passes through object props 1`] = `
+<ul
+  className=""
+>
+  <li
+    className=""
+    data-tid="list-item-0"
+    index={0}
+    onMouseEnter={[Function]}
+    test_attr="2"
+    value={1}
+  >
+    one
+  </li>
+  <li
+    className=""
+    data-tid="list-item-1"
+    index={1}
+    onMouseEnter={[Function]}
+    test_attr="2"
+    value={2}
+  >
+    two
+  </li>
+</ul>
+`;

--- a/packages/react-ui-core/src/Menu/Menu.js
+++ b/packages/react-ui-core/src/Menu/Menu.js
@@ -98,15 +98,6 @@ export default class Menu extends PureComponent {
     return this.props.options || []
   }
 
-  get items() {
-    return this.options.map(option =>
-      ((typeof option === 'object' && option.label !== undefined) ?
-        option.label :
-        option
-      )
-    )
-  }
-
   get highlightedOption() {
     return this.options[this.state.highlightIndex || 0]
   }
@@ -124,9 +115,9 @@ export default class Menu extends PureComponent {
 
   @autobind
   highlightOption(index) {
-    const { onItemMouseOver, options } = this.props
+    const { onItemMouseOver } = this.props
 
-    if (index < 0 || index >= options.length) return
+    if (index < 0 || index >= this.options.length) return
     this.setState({
       highlightIndex: index,
     }, () => {
@@ -157,7 +148,6 @@ export default class Menu extends PureComponent {
 
   render() {
     const {
-      options,
       theme,
       onItemMouseOver,
       className,
@@ -173,7 +163,7 @@ export default class Menu extends PureComponent {
           className,
           theme.Menu
         )}
-        items={this.items}
+        items={this.options || []}
         highlightIndex={this.state.highlightIndex}
         selectedIndex={selectedIndex}
         onClick={this.handleSelection}

--- a/packages/react-ui-core/src/Menu/__tests__/Menu-test.js
+++ b/packages/react-ui-core/src/Menu/__tests__/Menu-test.js
@@ -61,6 +61,11 @@ describe('Menu', () => {
     }
   }
 
+  it('should not barf if passed null options', () => {
+    const { wrapper } = setup({ theme, options: null })
+    expect(wrapper.find('ListItem')).toHaveLength(0)
+  })
+
   it('should pass options to List component', () => {
     const { wrapper } = setup({ theme, options })
     expect(wrapper.find('ListItem')).toHaveLength(3)
@@ -160,11 +165,6 @@ describe('Menu', () => {
   })
 
   describe('with object options', () => {
-    it('passes just the labels to List', () => {
-      const wrapper = shallow(<Menu options={objectOptions} />)
-      expect(wrapper.find(List).prop('items')).toEqual(objectOptions.map(obj => obj.label))
-    })
-
     it('passes the whole object to the onItemSelect function', () => {
       const onItemSelect = jest.fn()
       const wrapper = mount(<Menu options={objectOptions} onItemSelect={onItemSelect} />)

--- a/stories/core/Menu.js
+++ b/stories/core/Menu.js
@@ -6,22 +6,27 @@ const options = [
   {
     label: 'Best Match',
     value: 'best-match',
+    'data-tag_selection': 'best_match',
   },
   {
     label: 'Price (Highest to Lowest)',
     value: 'price-desc',
+    'data-tag_selection': 'price_highest_first',
   },
   {
     label: 'Price (Lowest to Highest)',
     value: 'price-asc',
+    'data-tag_selection': 'price_lowest_first',
   },
   {
     label: 'Distance (Nearest First)',
     value: 'distance',
+    'data-tag_selection': 'distance_nearest_first',
   },
   {
     label: 'Rating (High to Low)',
     value: 'rating',
+    'data-tag_selection': 'ratings_high_to_low',
   },
 ]
 


### PR DESCRIPTION
affects: @rentpath/react-ui-core

[Card](https://rentpath.leankit.com/card/591034222)

The Menu component wasn't passing additional props to its ListItems.
This prevented us from adding tagging attributes, etc.