### PR TITLE
Fixing list when the object is a valid react element

### DIFF
--- a/packages/react-ui-core/src/List/List.js
+++ b/packages/react-ui-core/src/List/List.js
@@ -60,7 +60,7 @@ export default class List extends PureComponent {
   }
 
   renderItem(item) {
-    if (typeof item === 'object') {
+    if (item && typeof item === 'object' && !React.isValidElement(item)) {
       const { label, ...props } = item
       return [label, props]
     } else if (typeof item === 'function') {


### PR DESCRIPTION
Fixes the list from rendering incorrectly when it gets passed an object that is also a valid react element