### PR TITLE
fix(@react-ui-core): upgrading Mapbox version

### DIFF
--- a/packages/react-ui-core/package.json
+++ b/packages/react-ui-core/package.json
@@ -53,7 +53,7 @@
     "babel-runtime": "6.26.0",
     "classnames": "2.2.5",
     "form-serialize": "0.7.2",
-    "mapbox-gl": "0.42.2",
+    "mapbox-gl": "0.44.2",
     "prop-types": "^15.6.1",
     "react-datepicker": "^1.3.0",
     "react-flexbox-grid": "https://github.com/rentpath/react-flexbox-grid",


### PR DESCRIPTION
affects: @rentpath/react-ui-core

IOS bug in our current version of MapBox https://bugs.webkit.org/show_bug.cgi?id=182521
This
upgrades Mapbox to fix this issue

BREAKING CHANGE:
0.44

Due to bug fixes #6005 and #6029, DragPanHandler, DragRotateHandler, and ScrollZoomHandler now fire map movement events (move, rotate, zoom, pitch) only once per render frame, rather than once per mouse/touch event. (See also issue #6047.)



0.43

It is now an error to attempt to remove a source that is in use #5562

It is now an error if the layer specified by the before parameter to moveLayer does not exist #5679

"colorSpace": "hcl" now uses shortest-path interpolation for hue #5811