### PR TITLE
Fix invalid use of `String.prototype.replace()`

### DIFF
--- a/packages/react-ui-utils/package.json
+++ b/packages/react-ui-utils/package.json
@@ -21,7 +21,8 @@
     "babel-plugin-transform-object-rest-spread": "6.26.0",
     "babel-preset-env": "1.6.1",
     "eslint": "^4.19.1",
-    "jest": "^22.4.3"
+    "jest": "^22.4.3",
+    "jsverify": "^0.8.3"
   },
   "dependencies": {
     "classnames": "2.2.5"

--- a/packages/react-ui-utils/src/__tests__/randomId-test.js
+++ b/packages/react-ui-utils/src/__tests__/randomId-test.js
@@ -1,3 +1,4 @@
+import jsc from 'jsverify'
 import randomId from '../randomId'
 
 describe('utils/randomId', () => {
@@ -6,7 +7,14 @@ describe('utils/randomId', () => {
     expect(randomId()).not.toBe(randomId())
   })
 
-  it('uses a custom prefix', () => {
-    expect(randomId('prefix').substr(0, 6)).toBe('prefix')
+  jsc.property('first part of id is a mathematical subset of input', jsc.nestring, str => {
+    const prefix = randomId(str).split('-')[0]
+    return prefix.length <= str.length
+  })
+
+  it('starts the random ID with an alphanumiric/hyphenated/underscored prefix passed to the function', () => {
+    const validString = jsc.suchthat(jsc.string, '', str => str.match(/^[a-z0-9-_]*$/))
+    const idStartsWithInput = jsc.forall(validString, str => randomId(str).startsWith(str))
+    jsc.check(idStartsWithInput)
   })
 })

--- a/packages/react-ui-utils/src/randomId.js
+++ b/packages/react-ui-utils/src/randomId.js
@@ -8,11 +8,20 @@ const randomStr = () => (
 )
 
 /**
+ * Generates a random number.
+ *
+ * @return {number}
+ */
+const randomNumber = () => (
+  Math.floor(Math.random() * 0xFFFF)
+)
+
+/**
  * Generates a random alphanumeric ID.
  *
  * @param {string} [prefix] An optional prefix.
  * @return {string}
  */
 export default prefix => (
-  `${prefix || randomStr()}-${Math.floor(Math.random() * 0xFFFF)}`.replace(/[^a-z0-9-_]/gi)
+  `${prefix || randomStr()}-${randomNumber()}`.replace(/[^a-z0-9-_]/gi, '')
 )


### PR DESCRIPTION
The method takes two arguments, but we were passing in one. A
replacement would result in "undefined" being injected into the output
string.