### PR TITLE
fix(mapbox): reverting mapbox due to crashing

### DIFF
--- a/packages/react-ui-core/package.json
+++ b/packages/react-ui-core/package.json
@@ -53,7 +53,7 @@
     "babel-runtime": "6.26.0",
     "classnames": "2.2.5",
     "form-serialize": "0.7.2",
-    "mapbox-gl": "0.44.2",
+    "mapbox-gl": "0.42.2",
     "prop-types": "^15.6.1",
     "react-basic-datepicker": "rentpath/react-basic-datepicker",
     "react-flexbox-grid": "https://github.com/rentpath/react-flexbox-grid",


### PR DESCRIPTION
affects: @rentpath/react-ui-core

Mapbox is crashing after bumping to `0.44.2`. reverting to enforce an exact version of `0.42.2`