### PR TITLE
fix(mapbox): making a peer dependency

### DIFF
--- a/packages/react-ui-core/package.json
+++ b/packages/react-ui-core/package.json
@@ -53,7 +53,6 @@
     "babel-runtime": "6.26.0",
     "classnames": "2.2.5",
     "form-serialize": "0.7.2",
-    "mapbox-gl": "0.42.2",
     "prop-types": "^15.6.1",
     "react-basic-datepicker": "rentpath/react-basic-datepicker",
     "react-flexbox-grid": "https://github.com/rentpath/react-flexbox-grid",
@@ -66,6 +65,7 @@
   },
   "peerDependencies": {
     "lodash": "^4.17.5",
+    "mapbox-gl": "0.42.2",
     "react": "^16.3.1",
     "react-dom": "^16.3.1"
   }


### PR DESCRIPTION
affects: @rentpath/react-ui-core

Changing mapbox-gl to a peer dependency so we have more control over it in the repo it's being used
in.