### PR TITLE
fix(react-ui-ag): export Marker in react-ui-ag's index

### DIFF
--- a/packages/react-ui-ag/src/index.js
+++ b/packages/react-ui-ag/src/index.js
@@ -36,6 +36,7 @@ export { EmailModal } from './Modals'
 export {
   Gmap,
   Markers,
+  Marker,
   PdpMap,
   markerRedDot,
   markerBlackDotIcon,


### PR DESCRIPTION
affects: @rentpath/react-ui-ag