### PR TITLE
fix(google maps): loader race condition

### DIFF
--- a/packages/react-ui-core/src/Gmap/__tests__/__snapshots__/withGoogleScript-test.js.snap
+++ b/packages/react-ui-core/src/Gmap/__tests__/__snapshots__/withGoogleScript-test.js.snap
@@ -1,13 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`withGoogleScript spinner does not use a spinner if none is passed 1`] = `<div />`;
+exports[`withGoogleScript spinner does not use a spinner if none is passed 1`] = `
+<div
+  loaded={true}
+/>
+`;
 
 exports[`withGoogleScript spinner uses the \`Spinner\` node passed with props 1`] = `
 Array [
   <span
     loading={false}
   />,
-  <div />,
+  <div
+    loaded={true}
+  />,
 ]
 `;
 
@@ -17,7 +23,9 @@ Array [
     data-tag_section="foo"
     loading={false}
   />,
-  <div />,
+  <div
+    loaded={true}
+  />,
 ]
 `;
 
@@ -28,6 +36,8 @@ Array [
   >
     spinner
   </div>,
-  <div />,
+  <div
+    loaded={true}
+  />,
 ]
 `;


### PR DESCRIPTION
affects: @rentpath/react-ui-core

Fixing google script loading race condition where 2 google map api scripts can't be on the page at
the same time

To replicate currently you have to add a `@rentpath/react-ui-ag` `PdpMap` to the PDP card
1. click on a listing on mobile srp
2. pdp card loads on srp route
3. gmaps gets mounted 
4. route changes to pdp (without reload)
5. pdp card loads on pdp route
6. gmaps gets mounted again

The amount of time in between routes causes a race condition where the gmaps api script loader thinks it doesn't have a script loaded yet so it tries to load another. The first one that tried to load on SRP is now unmounted so a global callback no longer works.  The only way seemingly to get this working properly is to add a global listener (and yes, I tried adding a global var, but you have the same issue).
