### PR TITLE
fix(google maps): switch to CustomEvent, so polyfill on IE11 will work

### DIFF
--- a/packages/react-ui-core/src/Gmap/withGoogleScript.js
+++ b/packages/react-ui-core/src/Gmap/withGoogleScript.js
@@ -95,7 +95,8 @@ export default function(BaseComponent) {
 
     @autobind
     scriptLoaded() {
-      window.dispatchEvent(new Event(EVENT_NAME))
+      // NOTE: IE 11 needs a polyfill for CustomEvent
+      window.dispatchEvent(new CustomEvent(EVENT_NAME))
     }
 
     loadScript() {


### PR DESCRIPTION
affects: @rentpath/react-ui-core