### PR TITLE
feat(GMAP): overlay Positioning

### DIFF
--- a/packages/react-ui-core/src/Gmap/OverlayView.js
+++ b/packages/react-ui-core/src/Gmap/OverlayView.js
@@ -121,7 +121,7 @@ export default class OverlayView extends PureComponent {
       // Projection is undefined if map has not yet initialized
       if (!projection) return
 
-      const { x, y } = this.overlay.getProjection().fromLatLngToDivPixel(position)
+      const { x, y } = projection.fromLatLngToDivPixel(position)
 
       // Show overlay only when it is in view.
       if (Math.abs(x) < 4000 && Math.abs(y) < 4000) {

--- a/packages/react-ui-core/src/Gmap/OverlayView.js
+++ b/packages/react-ui-core/src/Gmap/OverlayView.js
@@ -13,6 +13,10 @@ export default class OverlayView extends PureComponent {
     preventBubbleEvents: PropTypes.bool,
     className: PropTypes.string,
     theme: PropTypes.object,
+    overlayPosition: PropTypes.shape({
+      top: PropTypes.number,
+      left: PropTypes.number,
+    }),
   }
 
   static defaultProps = {
@@ -26,9 +30,10 @@ export default class OverlayView extends PureComponent {
   }
 
   componentDidUpdate(prevProps) {
-    const { anchor, theme, className } = this.props
+    const { anchor, theme, className, overlayPosition } = this.props
 
-    if (this.overlay && anchor !== prevProps.anchor) {
+    if (this.overlay && (anchor !== prevProps.anchor
+        || overlayPosition !== prevProps.overlayPosition)) {
       this.drawOverlay()
     }
 
@@ -116,13 +121,19 @@ export default class OverlayView extends PureComponent {
       // Projection is undefined if map has not yet initialized
       if (!projection) return
 
-      const { x, y } = projection.fromLatLngToDivPixel(position)
+      const { x, y } = this.overlay.getProjection().fromLatLngToDivPixel(position)
 
       // Show overlay only when it is in view.
       if (Math.abs(x) < 4000 && Math.abs(y) < 4000) {
         display = 'block'
-        this.container.style.left = `${x}px`
-        this.container.style.top = `${y}px`
+        if (this.props.overlayPosition) {
+          const { left, top } = this.props.overlayPosition
+          this.container.style.left = `${left}px`
+          this.container.style.top = `${top}px`
+        } else {
+          this.container.style.left = `${x}px`
+          this.container.style.top = `${y}px`
+        }
       }
     }
 


### PR DESCRIPTION
affects: @rentpath/react-ui-core

Add Prop to the GMAP OverlayView called overlayPosition. It lets you set the absolute position of
the overlay on the map. If it is not provided then the default positioning is used.