### PR TITLE
fix(Broaden event blacklist for overlay): fixes issue where ipad taps…

### DIFF
--- a/packages/react-ui-core/src/Gmap/OverlayView.js
+++ b/packages/react-ui-core/src/Gmap/OverlayView.js
@@ -43,6 +43,21 @@ export default class OverlayView extends PureComponent {
     }
   }
 
+  get eventBlacklist() {
+    return [
+      'click',
+      'contextmenu',
+      'dblclick',
+      'mousedown',
+      'mousemove',
+      'pointerdown',
+      'touchend',
+      'touchmove',
+      'touchstart',
+      'wheel',
+    ]
+  }
+
   get position() {
     const { anchor } = this.props
 
@@ -78,18 +93,7 @@ export default class OverlayView extends PureComponent {
 
   preventBubbleEvents() {
     const stopPropagation = e => e.stopPropagation()
-    const events = [
-      'click',
-      'dblclick',
-      'contextmenu',
-      'wheel',
-      'mousedown',
-      'mousemove',
-      'touchstart',
-      'pointerdown',
-    ]
-
-    events.forEach(event => (
+    this.eventBlacklist.forEach(event => (
       this.container.addEventListener(event, stopPropagation, false)
     ))
   }

--- a/packages/react-ui-core/src/Gmap/__tests__/OverlayView-test.js
+++ b/packages/react-ui-core/src/Gmap/__tests__/OverlayView-test.js
@@ -42,4 +42,10 @@ describe('OverlayView', () => {
     wrapper.setProps({ anchor: null })
     expect(container.style.display).toBe('none')
   })
+
+  it('eventBlacklist', () => {
+    const wrapper = createOverlayView()
+    const expected = wrapper.instance().eventBlacklist
+    expect(expected).toMatchSnapshot()
+  })
 })

--- a/packages/react-ui-core/src/Gmap/__tests__/__snapshots__/OverlayView-test.js.snap
+++ b/packages/react-ui-core/src/Gmap/__tests__/__snapshots__/OverlayView-test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OverlayView eventBlacklist 1`] = `
+Array [
+  "click",
+  "contextmenu",
+  "dblclick",
+  "mousedown",
+  "mousemove",
+  "pointerdown",
+  "touchend",
+  "touchmove",
+  "touchstart",
+  "wheel",
+]
+`;


### PR DESCRIPTION
Dont close the annotation window for IOS taps

affects: @rentpath/react-ui-core