### PR TITLE
ModalStack port to react-ui

### DIFF
--- a/packages/react-ui-ag/src/Listings/__tests__/DesktopListing-test.js
+++ b/packages/react-ui-ag/src/Listings/__tests__/DesktopListing-test.js
@@ -20,7 +20,6 @@ const baseListing = {
   rating: {
     score: 4,
     label: '20',
-    uniqueId: '111',
     count: 41,
     reviews: 2,
   },

--- a/packages/react-ui-core/src/Modal/Overlay.js
+++ b/packages/react-ui-core/src/Modal/Overlay.js
@@ -7,7 +7,6 @@ import autobind from 'autobind-decorator'
 @themed(/^Overlay/, {
   pure: true,
 })
-
 export default class Overlay extends PureComponent {
   static propTypes = {
     className: PropTypes.string,

--- a/packages/react-ui-core/src/ModalStack/ModalStack.js
+++ b/packages/react-ui-core/src/ModalStack/ModalStack.js
@@ -1,0 +1,151 @@
+import React, { PureComponent, Fragment } from 'react'
+import { createPortal } from 'react-dom'
+import autobind from 'autobind-decorator'
+import PropTypes from 'prop-types'
+import get from 'lodash/fp/get'
+import getOr from 'lodash/fp/getOr'
+import Overlay from '../Modal/Overlay'
+
+//
+// Expects currentModal to come in as an object that looks like
+// {
+//   id: modalId,
+//   props: { ...modalProps },
+// }
+//
+// Expects modalDefinitions to come in as an object that looks like
+// {
+//   modalId: {
+//     name: modalName,
+//     overlay: isOverlayOpen,
+//     resolve: () => import(modalPath),
+//   },
+// }
+//
+
+export default class ModalStack extends PureComponent {
+  static propTypes = {
+    currentModal: PropTypes.object,
+    modalDefinitions: PropTypes.object,
+    onClose: PropTypes.func,
+    modalPortalId: PropTypes.string,
+  }
+
+  static defaultProps = {
+    overlay: false,
+    modalPortalId: 'region-modal',
+    onClose: () => { },
+  }
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      currentDefinition: {},
+      modals: {},
+    }
+  }
+
+  componentDidMount() {
+    this.setupWrapperHost()
+  }
+
+  componentDidUpdate() {
+    // Change to didRecieveProps in future - though, in async rendering update,
+    // can resolve the correct component earlier
+    const { currentModal: { id = null }, modalDefinitions } = this.props
+
+    if (id && !this.getModalComponent(id)) {
+      const modalDefinition = get(id)(modalDefinitions)
+
+      if (modalDefinition) {
+        this.loadModal(modalDefinition).then(modal => {
+          this.setState({
+            currentDefinition: modalDefinition,
+            modals: {
+              ...this.state.modals,
+              // Need to test this, but this should help in case we are in an app
+              // that doesn't do auto module export of default
+              [id]: getOr(modal, 'default')(modal),
+            },
+          })
+        })
+      }
+    }
+  }
+
+  @autobind
+  onClose() {
+    const { currentModal, onClose } = this.props
+
+    if (onClose) onClose(currentModal.id)
+  }
+
+  getModalComponent(id) {
+    return this.state.modals[id]
+  }
+
+  setupWrapperHost() {
+    const { modalPortalId } = this.props
+
+    this.modalHost = document.getElementById(modalPortalId)
+    if (!this.modalHost) {
+      this.modalHost = document.createElement('section')
+      this.modalHost.id = modalPortalId
+      document.body.appendChild(this.modalHost)
+    }
+  }
+
+  @autobind
+  getWrapperComponent(useOverlay) {
+    const { currentModal } = this.props
+    return useOverlay
+      ? {
+        Component: Overlay,
+        props: {
+          key: `overlay-${currentModal.id}`,
+          onClick: this.onClose,
+        },
+      }
+      : {
+        Component: Fragment,
+        props: {},
+      }
+  }
+
+  async loadModal(definition) {
+    const result = await definition.resolve()
+    return result[definition.name]
+  }
+
+  @autobind
+  renderModals() {
+    const { currentModal } = this.props
+    const { currentDefinition } = this.state
+    const ModalComponent = this.getModalComponent(currentModal.id)
+
+    const Wrapper = this.getWrapperComponent(currentDefinition.overlay)
+
+    if (ModalComponent) {
+      return (
+        <Wrapper.Component {...Wrapper.props}>
+          <ModalComponent
+            key={`modal-${currentModal.id}`}
+            isOpen
+            onClose={this.onClose}
+            {...currentModal.props}
+          />
+        </Wrapper.Component>
+      )
+    }
+    return null
+  }
+
+  render() {
+    const { currentModal } = this.props
+
+    if (currentModal && currentModal.id && this.modalHost) {
+      return createPortal(this.renderModals(), this.modalHost)
+    }
+    return null
+  }
+}

--- a/packages/react-ui-core/src/ModalStack/__tests__/ModalStack-test.js
+++ b/packages/react-ui-core/src/ModalStack/__tests__/ModalStack-test.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import ModalStack from '../ModalStack'
+
+const modalDefinitions = {
+  1: {
+    name: 'TestModal',
+    resolve: () => import('../../LeadModal/LeadModal'),
+    overlay: true,
+  },
+}
+
+const currentModal = {
+  id: 1,
+  props: {
+    listingId: '100057144',
+    endecaId: '100057144_1330723',
+    propertyLabel: 'LEVEL Furnished Living',
+    desktopPhone: '2135684026',
+    tplSource: 'MYADS',
+    isPaid: true,
+    revenue: '17.16',
+  },
+}
+
+describe('ModalStack', () => {
+  it('renders correctly', () => {
+    const snap = renderer
+      .create(<ModalStack modalDefinitions={modalDefinitions} />)
+      .toJSON()
+    expect(snap).toMatchSnapshot()
+  })
+  it('renders a modal correctly', () => {
+    const snap = renderer
+      .create(<ModalStack currentModal={currentModal} modalDefinitions={modalDefinitions} />)
+      .toJSON()
+    expect(snap).toMatchSnapshot()
+  })
+})

--- a/packages/react-ui-core/src/ModalStack/__tests__/__snapshots__/ModalStack-test.js.snap
+++ b/packages/react-ui-core/src/ModalStack/__tests__/__snapshots__/ModalStack-test.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ModalStack renders a modal correctly 1`] = `null`;
+
+exports[`ModalStack renders correctly 1`] = `null`;

--- a/packages/react-ui-core/src/ModalStack/index.js
+++ b/packages/react-ui-core/src/ModalStack/index.js
@@ -1,0 +1,1 @@
+export { default as ModalStack } from './ModalStack'

--- a/packages/react-ui-core/src/index.js
+++ b/packages/react-ui-core/src/index.js
@@ -120,3 +120,7 @@ export {
   Markers,
   OverlayView,
 } from './Gmap'
+
+export {
+  ModalStack,
+} from './ModalStack'


### PR DESCRIPTION
Moving ModalStack back to react-ui, so both Rent and AG can use this

Added a comment, but will note here, because the input format might want to be talked about -

Expects currentModal to come in as an object that looks like
```
{
  id: modalId,
  props: { ...modalProps },
}
```
Expects modalDefinitions to come in as an object that looks like
```
{
  [modalId]: {
    name: modalName,
    overlay: isOverlayOpen,
    resolve: () => import(modalPath),
  }
}
```