### PR TITLE
fix(react-image-gallery): true lazy loading

### DIFF
--- a/packages/react-ui-core/package.json
+++ b/packages/react-ui-core/package.json
@@ -56,7 +56,7 @@
     "prop-types": "^15.6.1",
     "react-basic-datepicker": "rentpath/react-basic-datepicker",
     "react-flexbox-grid": "https://github.com/rentpath/react-flexbox-grid",
-    "react-image-gallery": "0.8.7",
+    "react-image-gallery": "rentpath/react-image-gallery",
     "react-input-range": "1.3.0",
     "react-lazyload": "2.3.0",
     "react-motion": "^0.5.2",


### PR DESCRIPTION
affects: @rentpath/react-ui-core

Forked the repo to address: https://github.com/xiaolin/react-image-gallery/issues/278

Gallery: https://github.com/xiaolin/react-image-gallery/compare/master...rentpath:master