### PR TITLE
feat(gmap): layer grey markers under red markers

### DIFF
--- a/packages/react-ui-ag/src/Gmap/Markers.js
+++ b/packages/react-ui-ag/src/Gmap/Markers.js
@@ -51,6 +51,7 @@ export default class Markers extends PureComponent {
           if (onMouseOut) onMouseOut(marker)
         },
         ...this.props.marker(feature),
+        zIndex: isActive ? 2 : 1,
       }
     }
   }

--- a/packages/react-ui-ag/src/Gmap/__tests__/Markers-test.js
+++ b/packages/react-ui-ag/src/Gmap/__tests__/Markers-test.js
@@ -20,10 +20,23 @@ describe('ag/Markers', () => {
         icon: redDotIcon(),
         onMouseOver: expect.any(Function),
         onMouseOut: expect.any(Function),
+        zIndex: 2,
       })
     })
 
-    it('uses a greyDotIcon for inactive properties', () => {
+    it('uses a redDotIcon with zIndex of 2 for active properties', () => {
+      const feature = {
+        properties: {
+          isActive: true,
+        },
+      }
+      const wrapper = shallow(<Markers map={map} markerIconHover={NOOP} />)
+      const instance = wrapper.instance()
+      expect(instance.marker(feature).icon).toEqual(redDotIcon())
+      expect(instance.marker(feature).zIndex).toEqual(2)
+    })
+
+    it('uses a greyDotIcon with zIndex of 1 for inactive properties', () => {
       const feature = {
         properties: {
           isActive: false,
@@ -32,6 +45,7 @@ describe('ag/Markers', () => {
       const wrapper = shallow(<Markers map={map} markerIconHover={NOOP} />)
       const instance = wrapper.instance()
       expect(instance.marker(feature).icon).toEqual(greyDotIcon())
+      expect(instance.marker(feature).zIndex).toEqual(1)
     })
 
     it('uses whatever icon is passed into markerInactiveIcon for inactive properties', () => {
@@ -47,6 +61,7 @@ describe('ag/Markers', () => {
       />)
       const instance = wrapper.instance()
       expect(instance.marker(feature).icon).toEqual(blackDotIcon())
+      expect(instance.marker(feature).zIndex).toEqual(1)
     })
 
     it('applies extra props correctly when passed as a `marker` prop', () => {
@@ -56,6 +71,7 @@ describe('ag/Markers', () => {
         icon: blackDotIconWithBalloon(),
         onMouseOver: expect.any(Function),
         onMouseOut: expect.any(Function),
+        zIndex: 2,
       })
     })
 


### PR DESCRIPTION
affects: @rentpath/react-ui-ag

Conditionally apply zIndex to markers based on `isActive`