### PR TITLE
feat(react-ui-ag & react-ui-core): reset carousel to initial index if…

### DIFF
--- a/packages/react-ui-ag/src/Listings/MobileListing.js
+++ b/packages/react-ui-ag/src/Listings/MobileListing.js
@@ -13,12 +13,15 @@ export default class MobileListing extends PureComponent {
     className: PropTypes.string,
     ratings: PropTypes.object,
     sponsoredText: PropTypes.string,
+    categoryMatch: PropTypes.bool,
+    noMatchText: PropTypes.string,
   }
 
   static defaultProps = {
     theme: {},
     listing: {},
     ratings: {},
+    categoryMatch: true,
   }
 
   get availabilityOrUpdated() {
@@ -38,10 +41,11 @@ export default class MobileListing extends PureComponent {
   }
 
   get renderTopComponents() {
-    const { theme, listing, ratings, sponsoredText } = this.props
+    const { theme, listing, ratings, sponsoredText, categoryMatch, noMatchText } = this.props
     const { singleFamily, rating, sponsored } = listing
     return !singleFamily && (
       <div className={theme.MobileListing_RatingAndSponsored}>
+        {!categoryMatch && <div className={theme.MobileListing_NoMatch}>{noMatchText}</div>}
         {rating && <ListingComponents.Ratings data-tid="ratings" {...ratings} />}
         {sponsored && <Text className={theme.MobileListing_Sponsored}>{sponsoredText}</Text>}
       </div>

--- a/packages/react-ui-core/src/Carousel/Carousel.js
+++ b/packages/react-ui-core/src/Carousel/Carousel.js
@@ -5,6 +5,7 @@ import classnames from 'classnames'
 import autobind from 'autobind-decorator'
 import Slider from 'react-image-gallery'
 import { forceCheck } from 'react-lazyload'
+import isEqual from 'lodash/isEqual'
 import { randomId, parseArgs } from '@rentpath/react-ui-utils'
 import { Button } from '../Button'
 import CarouselNavigation from './CarouselNavigation'
@@ -67,6 +68,10 @@ export default class Carousel extends Component {
   componentWillReceiveProps(nextProps) {
     if (this.props.selectedIndex !== nextProps.selectedIndex) {
       this.slideToIndex(nextProps.selectedIndex)
+    }
+
+    if (!isEqual(this.props.items, nextProps.items)) {
+      this.slideToIndex(0)
     }
   }
 


### PR DESCRIPTION
reset carousel to initial index if it gets new photos
give mobile listing props needed to display 'no matching photos' if visual search doesn't match
affects: @rentpath/react-ui-ag, @rentpath/react-ui-core