### PR TITLE
feat(ratings): adds support for top ratings summary

### DIFF
--- a/packages/react-ui-core/src/Ratings/RatingBar.js
+++ b/packages/react-ui-core/src/Ratings/RatingBar.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import themed from 'react-themed'
 import classnames from 'classnames'
 
-@themed(/^(RatingBar|Label)/, {
+@themed(/^(RatingBar|Label|Legend)/, {
   pure: true,
 })
 
@@ -19,6 +19,21 @@ export default class RatingBar extends PureComponent {
     theme: {},
     score: 0,
     maxScore: 5,
+  }
+
+  get ratingLegend(){
+    const {
+      theme, 
+      score,
+      ratingValue
+    } = this.props
+
+    return (
+      <div className={theme.Legend}>
+        <div className={theme.RatingBar_RatingValue}> {ratingValue} </div>
+        <div className={theme.RatingBar_LegendIcon}></div>
+      </div>
+    )
   }
 
   get ratingItems() {
@@ -43,7 +58,7 @@ export default class RatingBar extends PureComponent {
       </div>
     )
   }
-
+  
   render() {
     const {
       theme,
@@ -51,6 +66,7 @@ export default class RatingBar extends PureComponent {
       className,
       score,
       maxScore,
+      ratingValue,
       ...props
     } = this.props
 
@@ -64,8 +80,14 @@ export default class RatingBar extends PureComponent {
         }
         {...props}
       >
+        {ratingValue && this.ratingLegend}
         {this.ratingItems}
-        {label &&
+        {ratingValue && 
+          <div className={theme.Label}>
+            {score}
+          </div>
+        }
+        {label && 
           <div className={theme.Label}>
             {label}
           </div>

--- a/stories/core/RatingBar.js
+++ b/stories/core/RatingBar.js
@@ -57,3 +57,61 @@ export const HandleRatingClick = (
     label="Click a Star"
   />
 )
+
+export const RatingSummary = (
+  <RatingBar
+    className={theme.themedRating_summary}
+    ratingValue={5}
+    score={18}
+    maxScore={30}
+  />
+)
+
+export const LabeledRatingSummary = (
+  <RatingBar
+    className={theme.themedRating_summary}
+    ratingValue={5}
+    score={18}
+    maxScore={30}
+    label='of 30'
+  />
+)
+
+export const RatingSummaryGroup = (
+  <div>
+    <RatingBar
+      className={theme.themedRating_summary}
+      ratingValue={5}
+      score={18}
+      maxScore={30}
+    />
+
+    <RatingBar
+      className={theme.themedRating_summary}
+      ratingValue={4}
+      score={6}
+      maxScore={30}
+    />
+
+    <RatingBar
+      className={theme.themedRating_summary}
+      ratingValue={3}
+      score={3}
+      maxScore={30}
+    />
+
+    <RatingBar
+      className={theme.themedRating_summary}
+      ratingValue={2}
+      score={2}
+      maxScore={30}
+    />
+
+    <RatingBar
+      className={theme.themedRating_summary}
+      ratingValue={1}
+      score={1}
+      maxScore={30}
+    />
+  </div>
+)

--- a/stories/core/index.js
+++ b/stories/core/index.js
@@ -45,6 +45,9 @@ import {
   MaxScoreTenRatingBar,
   PartialRatingBar,
   HandleRatingClick,
+  RatingSummary,
+  RatingSummaryGroup,
+  LabeledRatingSummary
 } from './RatingBar'
 
 import {
@@ -233,6 +236,9 @@ coreStories('RatingBar', module)
   .add('Max Score of 10 Bar', () => MaxScoreTenRatingBar)
   .add('Partial Rating Bar', () => PartialRatingBar)
   .add('onClick for Rating Vote', () => HandleRatingClick)
+  .add('Rating Summary', () => RatingSummary)
+  .add('Labeled Rating Summary', () => LabeledRatingSummary)
+  .add('Rating Summary Group', () => RatingSummaryGroup)
 
 coreStories('Text', module)
   .add('Text', () => Text)

--- a/stories/theme/core/RatingBar.css
+++ b/stories/theme/core/RatingBar.css
@@ -1,5 +1,6 @@
 @value GoldStar: url(data:image/svg+xml;charset=utf8;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMCIgaGVpZ2h0PSIyMCIgdmlld0JveD0iMCAwIDUxIDQ4Ij48cGF0aCBmaWxsPSIjRkJCMTAwIiBkPSJNMjUgMWw2IDE3aDE4TDM1IDI5bDUgMTctMTUtMTAtMTUgMTAgNS0xN0wxIDE4aDE4eiIvPjwvc3ZnPg==);
 @value GrayStar: url(data:image/svg+xml;charset=utf8;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMCIgaGVpZ2h0PSIyMCIgdmlld0JveD0iMCAwIDUxIDQ4Ij48cGF0aCBmaWxsPSIjQ0VDRUNFIiBkPSJNMjUgMWw2IDE3aDE4TDM1IDI5bDUgMTctMTUtMTAtMTUgMTAgNS0xN0wxIDE4aDE4eiIvPjwvc3ZnPg==);
+@value BlueStar: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNCIgaGVpZ2h0PSIxNCIgdmlld0JveD0iMCAwIDE0IDE0Ij4gICAgPHBhdGggZmlsbD0iIzAwM0JERSIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNNi45NTggMGwxLjg4OCA1LjM0N2g1LjA3bC00LjEzNyAzLjE0TDExLjI1OCAxNGwtNC4zLTMuMzA1TDIuNjU4IDE0bDEuNDc5LTUuNTEyTDAgNS4zNDhoNS4wN3oiLz48L3N2Zz4=);
 
 .RatingBar .Label {
   text-align: center;
@@ -17,6 +18,37 @@
 .RatingBar_Background {
   overflow: hidden;
   background-repeat: repeat-x;
+}
+
+.Legend{
+  padding:0;
+}
+
+.RatingBar .Legend {
+  margin-right: 9.1px;
+  display:flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.RatingBar_LegendIcon{
+  width:14px;
+  height:14px;
+  background:BlueStar;
+  background-repeat: no-repeat;
+}
+
+.RatingBar_RatingValue{ 
+  font-size: 14px;
+  width:8px;
+  text-align: center;
+  margin-right:4px;
+  font-weight: bold;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: normal;
+  letter-spacing: normal;
+  color: #091540;
 }
 
 .themedRating_star .RatingBar_Icons,
@@ -87,4 +119,24 @@ width: 20px * 5 stars = 100px
 .themedRating_circle .RatingBar_Background {
   height: 20px;
   width: 100px;
+}
+
+.themedRating_summary{
+  display:flex;
+  height:14px;
+  align-items:center;
+  justify-content: space-around;
+  margin-bottom:21px;
+}
+
+.themedRating_summary .RatingBar_Icons {
+  border-radius: 2px;
+  background-color: #09bb3b;
+}
+
+.themedRating_summary .RatingBar_Background{
+  width: 267px;
+  height: 14px;
+  border-radius: 2px;
+  background-color: #ebebeb;
 }


### PR DESCRIPTION
Adds new prop of `ratingValue` to display as a key legend

<img width="387" alt="screen shot 2018-06-21 at 3 49 48 pm" src="https://user-images.githubusercontent.com/2365581/41742020-c92e25dc-756a-11e8-8279-25d73ff3da3b.png">


[Card - Reviews - Ratings top ratings component (RDS) ](https://rentpath.leankit.com/card/682447309)

