### PR TITLE
Remove slideToIndex

### DIFF
--- a/packages/react-ui-core/src/Carousel/Carousel.js
+++ b/packages/react-ui-core/src/Carousel/Carousel.js
@@ -5,7 +5,6 @@ import classnames from 'classnames'
 import autobind from 'autobind-decorator'
 import Slider from 'react-image-gallery'
 import { forceCheck } from 'react-lazyload'
-import isEqual from 'lodash/isEqual'
 import { randomId, parseArgs } from '@rentpath/react-ui-utils'
 import { Button } from '../Button'
 import CarouselNavigation from './CarouselNavigation'
@@ -68,10 +67,6 @@ export default class Carousel extends Component {
   componentWillReceiveProps(nextProps) {
     if (this.props.selectedIndex !== nextProps.selectedIndex) {
       this.slideToIndex(nextProps.selectedIndex)
-    }
-
-    if (!isEqual(this.props.items, nextProps.items)) {
-      this.slideToIndex(0)
     }
   }
 


### PR DESCRIPTION
[Card](https://rentpath.leankit.com/card/689327821)

This slideToIndex was causing sliding to index 0 when unexpected.
Turns out it was old code from visual search that is no longer needed.