### PR TITLE
fix(FreeDrawLayer): add onEnableMapDraw

### DIFF
--- a/packages/react-ui-core/src/Gmap/FreeDrawLayer.js
+++ b/packages/react-ui-core/src/Gmap/FreeDrawLayer.js
@@ -21,6 +21,7 @@ export default class FreeDrawLayer extends PureComponent {
     theme: PropTypes.object,
     map: PropTypes.object,
     onMapDrawStart: PropTypes.func,
+    onEnableMapDraw: PropTypes.func,
     onMapDrawEnd: PropTypes.func,
     shapes: PropTypes.object,
     multipleShapes: PropTypes.bool,
@@ -81,12 +82,13 @@ export default class FreeDrawLayer extends PureComponent {
 
   @autobind
   enableMapDraw() {
-    const { map, multipleShapes } = this.props
+    const { map, multipleShapes, onEnableMapDraw } = this.props
     this.disableMapControls()
 
-    if (!multipleShapes) {
-      this.clearAllShapes()
-    }
+    if (onEnableMapDraw) onEnableMapDraw()
+
+    if (!multipleShapes) this.clearAllShapes()
+
     this.events = setupEvents(map, GMAP_EVENTS, {
       onMouseDown: this.drawFreeHand,
     }, true)

--- a/packages/react-ui-core/src/Gmap/__tests__/FreeDrawLayer-test.js
+++ b/packages/react-ui-core/src/Gmap/__tests__/FreeDrawLayer-test.js
@@ -87,6 +87,13 @@ describe('FreeDrawLayer', () => {
       expect(fakeListener).toHaveBeenCalledWith(instance.props.map, 'mousedown', expect.any(Function))
     })
 
+    it('calls the onEnableMapDraw prop when the mousedown event is triggered', () => {
+      const onEnableMapDraw = jest.fn()
+      const instance = setup({ onEnableMapDraw })
+      instance.enableMapDraw()
+      expect(onEnableMapDraw).toHaveBeenCalled()
+    })
+
     it('calls the drawFreeHand function when the mousedown event is triggered', () => {
       const instance = setup()
       const spy = jest.spyOn(instance, 'drawFreeHand')


### PR DESCRIPTION
affects: @rentpath/react-ui-core

Add onEnableMapDraw to freeDrawLayer

Allows for onEnableMapDraw call back to be fired when enabling draw mode in free draw