### PR TITLE
fix(react-ui-ag): pass propertyName props through, prevent passing them to ApartmentComplex

### DIFF
--- a/packages/react-ui-ag/src/Listings/Listing.js
+++ b/packages/react-ui-ag/src/Listings/Listing.js
@@ -249,6 +249,7 @@ export default class Listing extends Component {
       listingTopComponents,
       onPhotoCarouselSlide,
       renderCustomControls,
+      index,
       ...props
     } = this.props
 

--- a/packages/react-ui-ag/src/Listings/MobileListing.js
+++ b/packages/react-ui-ag/src/Listings/MobileListing.js
@@ -14,12 +14,15 @@ export default class MobileListing extends PureComponent {
     ratings: PropTypes.object,
     categoryMatch: PropTypes.bool,
     noMatchText: PropTypes.string,
+    propertyName: PropTypes.object,
+    address: PropTypes.object,
   }
 
   static defaultProps = {
     theme: {},
     listing: {},
     ratings: {},
+    propertyName: {},
   }
 
   get availabilityOrUpdated() {
@@ -56,7 +59,7 @@ export default class MobileListing extends PureComponent {
   }
 
   get renderInfo() {
-    const { theme, listing } = this.props
+    const { theme, listing, propertyName, address } = this.props
     const { singleFamily } = listing
     return (
       <React.Fragment>
@@ -64,8 +67,8 @@ export default class MobileListing extends PureComponent {
 
         <Schema.NameAndUrl url={listing.url}>
           {singleFamily ?
-            <ListingComponents.Address /> :
-            <ListingComponents.PropertyName />
+            <ListingComponents.Address {...address} /> :
+            <ListingComponents.PropertyName {...propertyName} />
           }
         </Schema.NameAndUrl>
 
@@ -85,6 +88,8 @@ export default class MobileListing extends PureComponent {
       className,
       listing,
       ratings,
+      address,
+      propertyName,
       noMatchText,
       categoryMatch,
       ...props


### PR DESCRIPTION
affects: @rentpath/react-ui-ag

* pass propertyName props to `ListingComponents.PropertyName`
* prevent propertyName props from being passed down to `Listing`
* also added support for `address` props in the same way while I was at it

Note: I primarily did this because it was causing warnings in `ag.js`. I am trying to prevent warnings from printing while in tests in `ag.js`.