### PR TITLE
test(warnings): throw error on warning

### DIFF
--- a/packages/react-ui-ag/test/setup.js
+++ b/packages/react-ui-ag/test/setup.js
@@ -4,3 +4,14 @@ import enzyme from 'enzyme'
 // react 16 enzyme adapter
 enzyme.configure({ adapter: new Adapter() })
 
+/* eslint-disable no-console */
+const error = console.error
+
+// throw an error on react warnings so developers fix the warnings
+console.error = (message, ...args) => {
+  if (/(Invalid prop|Failed prop type|React does not recognize the `.*?` prop)/gi.test(message)) {
+    throw new Error(message)
+  }
+
+  error.apply(console, [message, ...args])
+}

--- a/packages/react-ui-core/test/setup.js
+++ b/packages/react-ui-core/test/setup.js
@@ -3,3 +3,15 @@ import enzyme from 'enzyme'
 
 // react 16 enzyme adapter
 enzyme.configure({ adapter: new Adapter() })
+
+/* eslint-disable no-console */
+const error = console.error
+
+// throw an error on react warnings so developers fix the warnings
+console.error = (message, ...args) => {
+  if (/(Invalid prop|Failed prop type|React does not recognize the `.*?` prop)/gi.test(message)) {
+    throw new Error(message)
+  }
+
+  error.apply(console, [message, ...args])
+}

--- a/packages/react-ui-rent/test/setup.js
+++ b/packages/react-ui-rent/test/setup.js
@@ -4,3 +4,14 @@ import enzyme from 'enzyme'
 // react 16 enzyme adapter
 enzyme.configure({ adapter: new Adapter() })
 
+/* eslint-disable no-console */
+const error = console.error
+
+// throw an error on react warnings so developers fix the warnings
+console.error = (message, ...args) => {
+  if (/(Invalid prop|Failed prop type|React does not recognize the `.*?` prop)/gi.test(message)) {
+    throw new Error(message)
+  }
+
+  error.apply(console, [message, ...args])
+}


### PR DESCRIPTION
affects: @rentpath/react-ui-ag, @rentpath/react-ui-core, @rentpath/react-ui-rent

Throw an error on any sort of React warning.
Includes:
- invalid props
- required props
- props injected into the DOM that aren't DOM attributes