### PR TITLE
ULA Text Refactor

### DIFF
--- a/packages/react-ui-ag/src/Listings/DesktopListing.js
+++ b/packages/react-ui-ag/src/Listings/DesktopListing.js
@@ -9,7 +9,7 @@ import Listing from './Listing'
   'DesktopListing',
   'BedsAndBaths',
   'UnitLevelAvailabilityAndLastUpdated',
-  'LastUpdated',
+  'UlaText',
   'Phone',
 ], { pure: true })
 export default class DesktopListing extends PureComponent {
@@ -47,7 +47,7 @@ export default class DesktopListing extends PureComponent {
           <ListingComponents.Availability /> :
           (
             <div className={theme.UnitLevelAvailabilityAndLastUpdated}>
-              {ulaText && <div className={theme.UlaText}>{ulaText}</div>}
+              {ulaText && <div className={theme.UlaText} data-tid="ulaText">{ulaText}</div>}
             </div>
           )
         }

--- a/packages/react-ui-ag/src/Listings/DesktopListing.js
+++ b/packages/react-ui-ag/src/Listings/DesktopListing.js
@@ -30,7 +30,7 @@ export default class DesktopListing extends PureComponent {
 
   get renderInfo() {
     const { theme, listing, ratings, propertyName } = this.props
-    const { singleFamily, rating, lastUpdated, phone } = listing
+    const { singleFamily, rating, ulaText, phone } = listing
 
     return (
       <React.Fragment>
@@ -47,8 +47,7 @@ export default class DesktopListing extends PureComponent {
           <ListingComponents.Availability /> :
           (
             <div className={theme.UnitLevelAvailabilityAndLastUpdated}>
-              <ListingComponents.UnitLevelAvailability />
-              {lastUpdated && <div className={theme.LastUpdated}>{lastUpdated}</div>}
+              {ulaText && <div className={theme.UlaText}>{ulaText}</div>}
             </div>
           )
         }

--- a/packages/react-ui-ag/src/Listings/__tests__/DesktopListing-test.js
+++ b/packages/react-ui-ag/src/Listings/__tests__/DesktopListing-test.js
@@ -11,6 +11,7 @@ const baseListing = {
   bedrooms: '1-3 Beds',
   bathrooms: '2 Baths',
   unitLevelAvailability: '12 Units Available',
+  ulaText: '9 units available',
   lastUpdated: '3hrs ago',
   name: 'Awesome Property!',
   city: 'Great Town',
@@ -134,17 +135,10 @@ describe('DesktopListing', () => {
         expect(wrapper.find(ListingComponents.Bathroom).exists()).toBeTruthy()
       })
 
-      it('renders UnitLevelAvailability component', () => {
+      it('renders ulaText div', () => {
         const wrapper = mount(<DesktopListing {...props} />)
-        expect(wrapper
-          .find(ListingComponents.UnitLevelAvailability).exists())
-          .toBeTruthy()
-      })
-
-      it('renders lastUpdated div', () => {
-        const wrapper = mount(<DesktopListing {...props} />)
-        expect(wrapper.find('.LastUpdated').at(0).text())
-          .toEqual(baseListing.lastUpdated)
+        expect(wrapper.find('.UlaText').at(0).text())
+            .toEqual(baseListing.ulaText || baseListing.lastUpdated)
       })
 
       it('renders PropertyName component', () => {

--- a/packages/react-ui-ag/src/Listings/__tests__/DesktopListing-test.js
+++ b/packages/react-ui-ag/src/Listings/__tests__/DesktopListing-test.js
@@ -137,7 +137,8 @@ describe('DesktopListing', () => {
 
       it('renders ulaText div', () => {
         const wrapper = mount(<DesktopListing {...props} />)
-        expect(wrapper.find('.UlaText').at(0).text())
+        console.log(wrapper.find('.UlaText'))
+        expect(wrapper.find('.UlaText').text())
             .toEqual(baseListing.ulaText || baseListing.lastUpdated)
       })
 

--- a/packages/react-ui-ag/src/Listings/__tests__/mocks/theme.js
+++ b/packages/react-ui-ag/src/Listings/__tests__/mocks/theme.js
@@ -6,7 +6,7 @@ export default keyMirror([
   'MobileMapListing-inactive',
   'DesktopListing',
   'BedsAndBaths',
-  'LastUpdated',
+  'UlaText',
   'Phone',
   'MobileListing',
   'Listing',

--- a/stories/theme/ag/large/Listings/DesktopListing.css
+++ b/stories/theme/ag/large/Listings/DesktopListing.css
@@ -216,7 +216,7 @@ a.DesktopListing .Listing_CtaButton {
   margin-top: 2px;
 }
 
-.DesktopListing .LastUpdated {
+.DesktopListing .UlaText {
   margin-left: 3px;
 }
 
@@ -227,7 +227,7 @@ a.DesktopListing .Listing_CtaButton {
 }
 
 .DesktopListing .UnitLevelAvailability,
-.DesktopListing .LastUpdated,
+.DesktopListing .UlaText,
 .DesktopListing .Availability {
   white-space: nowrap;
   overflow: hidden;


### PR DESCRIPTION
[Card](https://rentpath.leankit.com/card/682372371)

Acceptance Criteria:

Update ULA and Last Updated text logic to change to as follows
If there is ULA then show only ULA
IF there is ULA and Last Updated information show only ULA
If there is no ULA and there is last updated information then show the last updated information
If there is no ULA and No Last updated information then show a blank row
In all situations remove the "clock" icon currenlty shown between ULA and last updated.

How it related to `react-ui`:
This card asks not to display `ULA`(UnitLevelAvailability: "9 units available") and `LastUpdated` at the same time and primarily display `ULA` and then fall back to LastUpdated when `ULA` not present.

Made changes in react-ui to remove not used `div` to match props currently in `DesktopListing.js`

Link to related PR:
https://github.com/rentpath/ag.js/pull/4853

What it will look like:
![screen shot 2018-08-10 at 12 31 50 pm](https://user-images.githubusercontent.com/23741323/43969845-7493a88e-9c99-11e8-91a6-72e210d72a99.png)

