### PR TITLE
fix(MoreOptions): replace generic button

### DIFF
--- a/packages/react-ui-ag/src/Listings/__tests__/DesktopListing-test.js
+++ b/packages/react-ui-ag/src/Listings/__tests__/DesktopListing-test.js
@@ -137,7 +137,6 @@ describe('DesktopListing', () => {
 
       it('renders ulaText div', () => {
         const wrapper = mount(<DesktopListing {...props} />)
-        console.log(wrapper.find('.UlaText'))
         expect(wrapper.find('.UlaText').text())
             .toEqual(baseListing.ulaText || baseListing.lastUpdated)
       })

--- a/packages/react-ui-ag/src/Modals/MoreOptionsModal.js
+++ b/packages/react-ui-ag/src/Modals/MoreOptionsModal.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import themed from 'react-themed'
 import autobind from 'autobind-decorator'
 import classnames from 'classnames'
-import { Modal, Button, Text } from '@rentpath/react-ui-core'
+import { Modal, Button, Text, ApplyButton, CancelButton } from '@rentpath/react-ui-core'
 
 @themed(/^MoreOptionsModal/, { pure: true })
 
@@ -119,18 +119,18 @@ export default class MoreOptionsModal extends PureComponent {
           Reset All
         </Button>
         <div className={theme.MoreOptionsModal_FooterButtons}>
-          <Button
+          <CancelButton
             className={theme.MoreOptionsModal_Cancel}
             onClick={this.handleCancel}
           >
             Cancel
-          </Button>
-          <Button
+          </CancelButton>
+          <ApplyButton
             className={theme.MoreOptionsModal_Submit}
             onClick={this.handleSubmit}
           >
             {submitButton}
-          </Button>
+          </ApplyButton>
         </div>
       </div>
     )

--- a/packages/react-ui-ag/src/Modals/__tests__/MoreOptionsModal-test.js
+++ b/packages/react-ui-ag/src/Modals/__tests__/MoreOptionsModal-test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { mount, shallow } from 'enzyme'
-import { Button, Text } from '@rentpath/react-ui-core'
+import { Button, Text, ApplyButton, CancelButton } from '@rentpath/react-ui-core'
 import theme from './mocks/theme'
 import ThemedMoreOptionsModal from '../MoreOptionsModal'
 
@@ -42,7 +42,7 @@ describe('MoreOptionsModal', () => {
   describe('cancel button', () => {
     it('closes modal and restores filters on click', () => {
       const wrapper = mount(<MoreOptionsModal {...props} />)
-      const cancelButton = wrapper.find('.MoreOptionsModal_Cancel').at(0)
+      const cancelButton = wrapper.find(CancelButton)
       const cancelButtonText = cancelButton.text()
 
       cancelButton.simulate('click')
@@ -91,7 +91,7 @@ describe('MoreOptionsModal', () => {
   })
 
   describe('property count', () => {
-    const submit = wrapper => wrapper.find('.MoreOptionsModal_Submit').childAt(0)
+    const submit = wrapper => wrapper.find(ApplyButton).dive().childAt(0)
     const header = wrapper => wrapper.find(Text).dive().childAt(0)
 
     it('displays the total when there is no "filterTotal"', () => {

--- a/packages/react-ui-core/src/Button/ApplyButton.js
+++ b/packages/react-ui-core/src/Button/ApplyButton.js
@@ -12,15 +12,15 @@ import Button from './Button'
 export default class ApplyButton extends PureComponent {
   static propTypes = {
     className: PropTypes.string,
+    children: PropTypes.node,
     onClick: PropTypes.func,
     theme: PropTypes.object,
-    name: PropTypes.node,
     value: PropTypes.any,
   }
 
   static defaultProps = {
+    children: 'Apply',
     theme: {},
-    name: 'Apply',
   }
 
   @autobind
@@ -33,9 +33,9 @@ export default class ApplyButton extends PureComponent {
   render() {
     const {
       theme,
-      name,
       className,
       onClick,
+      children,
       value,
       ...props
     } = this.props
@@ -52,7 +52,7 @@ export default class ApplyButton extends PureComponent {
         data-tid="apply-button"
         {...props}
       >
-        {name}
+        {children}
       </Button>
     )
   }

--- a/packages/react-ui-core/src/Button/CancelButton.js
+++ b/packages/react-ui-core/src/Button/CancelButton.js
@@ -12,15 +12,15 @@ import Button from './Button'
 export default class CancelButton extends PureComponent {
   static propTypes = {
     className: PropTypes.string,
+    children: PropTypes.node,
     onClick: PropTypes.func,
     theme: PropTypes.object,
-    name: PropTypes.node,
     value: PropTypes.any,
   }
 
   static defaultProps = {
+    children: 'Cancel',
     theme: {},
-    name: 'Cancel',
   }
 
   @autobind
@@ -33,9 +33,9 @@ export default class CancelButton extends PureComponent {
   render() {
     const {
       theme,
-      name,
       className,
       onClick,
+      children,
       ...props
     } = this.props
 
@@ -51,7 +51,7 @@ export default class CancelButton extends PureComponent {
         data-tid="cancel-button"
         {...props}
       >
-        {name}
+        {children}
       </Button>
     )
   }

--- a/packages/react-ui-core/src/Button/__tests__/ApplyButton-tests.js
+++ b/packages/react-ui-core/src/Button/__tests__/ApplyButton-tests.js
@@ -23,7 +23,8 @@ describe('ag/Buttons/ApplyButton', () => {
   })
 
   it('allows an override of the name', () => {
-    const wrapper = shallow(<ApplyButton name="Do not apply!!!" onClick={() => null} />)
+    const children = 'Do not apply!!!'
+    const wrapper = shallow(<ApplyButton onClick={() => null}>{children}</ApplyButton>)
     expect(wrapper.find(Button).children().text()).toEqual('Do not apply!!!')
   })
 

--- a/packages/react-ui-core/src/Button/__tests__/CancelButton-tests.js
+++ b/packages/react-ui-core/src/Button/__tests__/CancelButton-tests.js
@@ -23,7 +23,8 @@ describe('ag/Buttons/CancelButton', () => {
   })
 
   it('allows an override of the name', () => {
-    const wrapper = shallow(<CancelButton name="Do not cancel!!!" onClick={() => null} />)
+    const children = 'Do not cancel!!!'
+    const wrapper = shallow(<CancelButton onClick={() => null}>{children}</CancelButton>)
     expect(wrapper.find(Button).children().text()).toEqual('Do not cancel!!!')
   })
 


### PR DESCRIPTION
affects: @rentpath/react-ui-ag

Replace generic buttons with ApplyButton and CancelButton and their concerning test

Reason for change:
Will reduce default styling for this PR
https://github.com/rentpath/ag.js/pull/4947/files