### PR TITLE
Removing react-spinners and implementing bounce-spinner

### DIFF
--- a/packages/react-ui-core/package.json
+++ b/packages/react-ui-core/package.json
@@ -59,7 +59,6 @@
     "react-input-range": "1.3.0",
     "react-lazyload": "2.3.0",
     "react-motion": "^0.5.2",
-    "react-spinners": "^0.3.2",
     "react-themed": "3.2.1"
   },
   "peerDependencies": {

--- a/packages/react-ui-core/src/Gmap/GmapSpinner.js
+++ b/packages/react-ui-core/src/Gmap/GmapSpinner.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import themed from 'react-themed'
 import classnames from 'classnames'
-import { BounceLoader } from 'react-spinners'
+import BounceLoader from './spinners/BounceLoader'
 
 @themed(['Gmap_Spinner'], { pure: true })
 

--- a/packages/react-ui-core/src/Gmap/spinners/BounceLoader.js
+++ b/packages/react-ui-core/src/Gmap/spinners/BounceLoader.js
@@ -1,0 +1,64 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+
+const defaultAnimationStyle = i =>
+  `BOUNCELOADER 2.1s ${i === 1 ? '1s' : '0s'} infinite ease-in-out`
+
+class Loader extends Component {
+  static propTypes = {
+    loading: PropTypes.bool,
+    color: PropTypes.string,
+    size: PropTypes.number,
+    sizeUnit: PropTypes.string,
+    className: PropTypes.string,
+    animation: PropTypes.func,
+  };
+
+  static defaultProps = {
+    loading: true,
+    color: '#000000',
+    size: 60,
+    sizeUnit: 'px',
+    className: '',
+    animation: defaultAnimationStyle,
+  };
+
+  style(i) {
+    const { size, color, sizeUnit, animation } = this.props
+
+    return {
+      position: 'absolute',
+      height: `${size}${sizeUnit}`,
+      width: `${size}${sizeUnit}`,
+      backgroundColor: `${color}`,
+      borderRadius: '100%',
+      opacity: 0.6,
+      top: 0,
+      left: 0,
+      animationFillMode: 'both',
+      animation: animation(i),
+    }
+  }
+
+  wrapperStyles() {
+    const { size, sizeUnit } = this.props
+
+    return {
+      position: 'relative',
+      width: `${size}${sizeUnit}`,
+      height: `${size}${sizeUnit}`,
+    }
+  }
+  render() {
+    const { loading, className } = this.props
+
+    return loading ? (
+      <div style={this.wrapperStyles()} className={className}>
+        <div style={this.style(1)} />
+        <div style={this.style(2)} />
+      </div>
+    ) : null
+  }
+}
+
+export default Loader


### PR DESCRIPTION
React-spinners imports a bunch of dependencies

Since we only use bounce-spinner right now, ported that in a simple fashion