### PR TITLE
version bump: react-ui calendar

### DIFF
--- a/packages/react-ui-core/package.json
+++ b/packages/react-ui-core/package.json
@@ -53,7 +53,7 @@
     "classnames": "^2.2.6",
     "form-serialize": "0.7.2",
     "prop-types": "^15.6.1",
-    "react-basic-datepicker": "rentpath/react-basic-datepicker",
+    "react-basic-datepicker": "rentpath/react-basic-datepicker#3ca6bd52e6e55419",
     "react-image-gallery": "rentpath/react-image-gallery",
     "react-input-mask": "^2.0.3",
     "react-input-range": "1.3.0",


### PR DESCRIPTION
Updated the [react-basic-datepicker](https://github.com/rentpath/react-basic-datepicker) in response to below card. Requires a version bump. 

[Card](https://rentpath.leankit.com/card/697016601)