### PR TITLE
feat(Markers): grey pins for isBasic listings

### DIFF
--- a/packages/react-ui-ag/src/Gmap/Markers.js
+++ b/packages/react-ui-ag/src/Gmap/Markers.js
@@ -37,8 +37,8 @@ export default class Markers extends PureComponent {
     } = this.props
 
     return feature => {
-      const isActive = get(feature, 'properties.isActive', true)
-      const icon = isActive ? markerIcon : markerInactiveIcon
+      const isBasic = get(feature, 'properties.isBasic', false)
+      const icon = !isBasic ? markerIcon : markerInactiveIcon
 
       return {
         icon: icon(),
@@ -51,7 +51,7 @@ export default class Markers extends PureComponent {
           if (onMouseOut) onMouseOut(marker)
         },
         ...this.props.marker(feature),
-        zIndex: isActive ? 2 : 1,
+        zIndex: !isBasic ? 2 : 1,
       }
     }
   }

--- a/packages/react-ui-ag/src/Gmap/__tests__/Markers-test.js
+++ b/packages/react-ui-ag/src/Gmap/__tests__/Markers-test.js
@@ -24,10 +24,10 @@ describe('ag/Markers', () => {
       })
     })
 
-    it('uses a redDotIcon with zIndex of 2 for active properties', () => {
+    it('uses a redDotIcon with zIndex of 2 for non-basic properties', () => {
       const feature = {
         properties: {
-          isActive: true,
+          isBasic: false,
         },
       }
       const wrapper = shallow(<Markers map={map} markerIconHover={NOOP} />)
@@ -36,10 +36,10 @@ describe('ag/Markers', () => {
       expect(instance.marker(feature).zIndex).toEqual(2)
     })
 
-    it('uses a greyDotIcon with zIndex of 1 for inactive properties', () => {
+    it('uses a greyDotIcon with zIndex of 1 for isBasic properties', () => {
       const feature = {
         properties: {
-          isActive: false,
+          isBasic: true,
         },
       }
       const wrapper = shallow(<Markers map={map} markerIconHover={NOOP} />)
@@ -48,10 +48,10 @@ describe('ag/Markers', () => {
       expect(instance.marker(feature).zIndex).toEqual(1)
     })
 
-    it('uses whatever icon is passed into markerInactiveIcon for inactive properties', () => {
+    it('uses whatever icon is passed into markerInactiveIcon for isBasic properties', () => {
       const feature = {
         properties: {
-          isActive: false,
+          isBasic: true,
         },
       }
       const wrapper = shallow(<Markers


### PR DESCRIPTION
[Card](https://rentpath.leankit.com/card/716386936)

affects: @rentpath/react-ui-ag

All isBasic listings should now receive the grey pin, rather than just the !isActive listings.  isBasic listings are composed of tplsource === 'INACTIVE' + tplsource === 'LNP' (aka "Large Never Paid"). The LNP listings are a new set being added by the inventory team.