### PR TITLE
feat(OverlayView): add event handlers to OverlayView

### DIFF
--- a/packages/react-ui-core/src/Gmap/OverlayView.js
+++ b/packages/react-ui-core/src/Gmap/OverlayView.js
@@ -3,6 +3,18 @@ import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
 import themed from 'react-themed'
 import classnames from 'classnames'
+import { setupEvents } from './utils/mapEventHelpers'
+
+const EVENTS = {
+  onClick: 'click',
+  onDoubleClick: 'dblclick',
+  onMouseDown: 'mousedown',
+  onMouseOut: 'mouseout',
+  onMouseOver: 'mouseover',
+  onMouseUp: 'mouseup',
+}
+
+const EVENT_NAMES = Object.keys(EVENTS)
 
 @themed(/^Gmap_OverlayView/, { pure: true })
 export default class OverlayView extends PureComponent {
@@ -45,7 +57,6 @@ export default class OverlayView extends PureComponent {
 
   get eventBlacklist() {
     return [
-      'click',
       'contextmenu',
       'dblclick',
       'mousedown',
@@ -87,6 +98,8 @@ export default class OverlayView extends PureComponent {
     this.overlay.onAdd = this.addChildren.bind(this)
     this.overlay.onRemove = this.removeChildren.bind(this)
     this.overlay.draw = this.drawOverlay.bind(this)
+
+    setupEvents(this.container, EVENTS, this.props, false, 'addDomListener')
 
     this.overlay.setMap(map)
   }
@@ -144,3 +157,7 @@ export default class OverlayView extends PureComponent {
     )
   }
 }
+
+EVENT_NAMES.forEach(name => {
+  OverlayView.propTypes[name] = PropTypes.func
+})

--- a/packages/react-ui-core/src/Gmap/__tests__/__snapshots__/OverlayView-test.js.snap
+++ b/packages/react-ui-core/src/Gmap/__tests__/__snapshots__/OverlayView-test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`OverlayView eventBlacklist 1`] = `
 Array [
-  "click",
   "contextmenu",
   "dblclick",
   "mousedown",

--- a/packages/react-ui-core/src/Gmap/utils/mapEventHelpers.js
+++ b/packages/react-ui-core/src/Gmap/utils/mapEventHelpers.js
@@ -1,9 +1,9 @@
 export const handleEvent = (instance, name, props) =>
   event => props[name](event, props, instance)
 
-export const setupEvents = (instance, events, props, once) => {
+export const setupEvents = (instance, events, props, once = false, addListener = 'addListener') => {
   const eventNames = Object.keys(events)
-  const type = once ? 'addListenerOnce' : 'addListener'
+  const type = once ? `${addListener}Once` : addListener
   const eventHandlers = {}
   eventNames.forEach(name => {
     if (props[name] && typeof props[name] === 'function') {


### PR DESCRIPTION
affects: @rentpath/react-ui-core

[Card](https://rentpath.leankit.com/card/718095899)

OverlayView was not accepting event handlers as props. The way google maps create OverlayViews, it
was also necessary to use `addDomListener` instead.