### PR TITLE
Use setState callback to ensure state despite asynchrony

### DIFF
--- a/packages/react-ui-core/src/Dropdown/Dropdown.js
+++ b/packages/react-ui-core/src/Dropdown/Dropdown.js
@@ -54,21 +54,25 @@ export default class Dropdown extends Component {
     const { onVisibilityChange, toggleOnSelect } = this.props
     const visible = toggleOnSelect ? !this.state.visible : true
 
-    this.setState({ visible })
     if (this.state.visible !== visible) {
       onVisibilityChange(visible)
+      this.setState({ visible })
     }
   }
 
   @autobind
-  changeVisibility(visible) {
-    this.props.onVisibilityChange(visible)
-    this.setState({ visible })
-  }
-
-  @autobind
   handleDocumentClick(event) {
-    if (this.state.visible && !this.dropdown.contains(event.target)) {
+    const eventTarget = event.target
+    const parentTarget = event.target.parentNode
+    const parentIsDropdown = this.dropdown.contains(parentTarget) &&
+      parentTarget.dataset.self === 'dropdown'
+
+    const targetIsDropdown = this.dropdown.contains(eventTarget) ||
+      parentIsDropdown
+
+    const shouldFireEvent = this.state.visible && !targetIsDropdown
+
+    if (shouldFireEvent) {
       this.setState({ visible: false })
       this.props.onVisibilityChange(false)
     }
@@ -115,6 +119,7 @@ export default class Dropdown extends Component {
           className
         )}
         {...props}
+        data-self="dropdown"
       >
         {this.renderAnchor()}
         {this.state.visible &&


### PR DESCRIPTION
Depending on `this.state` before and after the call can cause a subtle bug (in this case calling the onVisibilityChange callback twice when a parent component calls `setState`). Using the callback syntax to set state and the after set callback ensures that everything happens synchronously and the values in `this.state` are what we expect.

#### **Edit:** This is the real issue below

It is possible with event queueing that the caught event is that of the immediate child.
Include a
new and specific data attribute to reliably check to see if the Dropdown or the anchor is the target
of the click.
Also clean up setState logic in toggleVisibility to not rely on state before and
after setState call.