### PR TITLE
fix(modal): add data-tid to modal close button

### DIFF
--- a/packages/react-ui-core/src/Modal/Modal.js
+++ b/packages/react-ui-core/src/Modal/Modal.js
@@ -58,7 +58,13 @@ export default class Modal extends PureComponent {
 
     if (CloseButton) {
       const [Close, props] = parseArgs(CloseButton, ModalCloseButton)
-      return <Close {...props} onClick={this.overlayClose} />
+      return (
+        <Close
+          data-tid="close-modal"
+          {...props}
+          onClick={this.overlayClose}
+        />
+      )
     }
 
     return null

--- a/packages/react-ui-core/src/Modal/ModalCloseButton.js
+++ b/packages/react-ui-core/src/Modal/ModalCloseButton.js
@@ -33,7 +33,7 @@ export default class CloseButton extends PureComponent {
           className,
           theme.CloseButton
         )}
-        data-tid="modal-close-button"
+        data-tid="close-modal"
         {...props}
       >
         {children}

--- a/packages/react-ui-core/src/Modal/__tests__/__snapshots__/ModalCloseButton-test.js.snap
+++ b/packages/react-ui-core/src/Modal/__tests__/__snapshots__/ModalCloseButton-test.js.snap
@@ -3,7 +3,7 @@
 exports[`ModalCloseButton renders children passed 1`] = `
 <div
   className=""
-  data-tid="modal-close-button"
+  data-tid="close-modal"
 >
   Close
 </div>
@@ -12,7 +12,7 @@ exports[`ModalCloseButton renders children passed 1`] = `
 exports[`ModalCloseButton renders default children if none passed 1`] = `
 <div
   className=""
-  data-tid="modal-close-button"
+  data-tid="close-modal"
 >
   X
 </div>


### PR DESCRIPTION
* changing generic data-tid="close-modal" in ModalCloseButton
* adding generic data-tid="close-modal" to CloseButton so both
custom CloseButton and generic one get the same (will making e2e easier) 

affects: @rentpath/react-ui-core