### PR TITLE
feat(Markers): zIndex aptguide map pins above other pins

### DIFF
--- a/packages/react-ui-ag/src/Gmap/Markers.js
+++ b/packages/react-ui-ag/src/Gmap/Markers.js
@@ -39,6 +39,8 @@ export default class Markers extends PureComponent {
     return feature => {
       const isBasic = get(feature, 'properties.isBasic', false)
       const scale = get(feature, 'properties.iconScale', 1)
+      const source = get(feature, 'properties.source', '')
+      const zIndex = typeof source === 'string' && source.toLowerCase() === 'aptguide' ? 2 : 1
       const icon = !isBasic ? markerIcon : markerInactiveIcon
 
       return {
@@ -52,7 +54,7 @@ export default class Markers extends PureComponent {
           if (onMouseOut) onMouseOut(marker)
         },
         ...this.props.marker(feature),
-        zIndex: !isBasic ? 2 : 1,
+        zIndex,
       }
     }
   }

--- a/packages/react-ui-ag/src/Gmap/__tests__/Markers-test.js
+++ b/packages/react-ui-ag/src/Gmap/__tests__/Markers-test.js
@@ -20,20 +20,32 @@ describe('ag/Markers', () => {
         icon: redDotIcon(),
         onMouseOver: expect.any(Function),
         onMouseOut: expect.any(Function),
-        zIndex: 2,
+        zIndex: 1,
       })
     })
 
-    it('uses a redDotIcon with zIndex of 2 for non-basic properties', () => {
+    it('uses a redDotIcon with zIndex of 2 for aptguide properties', () => {
       const feature = {
         properties: {
-          isBasic: false,
+          source: 'aptguide',
         },
       }
       const wrapper = shallow(<Markers map={map} markerIconHover={NOOP} />)
       const instance = wrapper.instance()
       expect(instance.marker(feature).icon).toEqual(redDotIcon())
       expect(instance.marker(feature).zIndex).toEqual(2)
+    })
+
+    it('uses a redDotIcon with zIndex of 1 for non-aptguide properties', () => {
+      const feature = {
+        properties: {
+          source: 'foo',
+        },
+      }
+      const wrapper = shallow(<Markers map={map} markerIconHover={NOOP} />)
+      const instance = wrapper.instance()
+      expect(instance.marker(feature).icon).toEqual(redDotIcon())
+      expect(instance.marker(feature).zIndex).toEqual(1)
     })
 
     it('uses a greyDotIcon with zIndex of 1 for isBasic properties', () => {
@@ -124,7 +136,7 @@ describe('ag/Markers', () => {
         icon: blackDotIconWithBalloon(),
         onMouseOver: expect.any(Function),
         onMouseOut: expect.any(Function),
-        zIndex: 2,
+        zIndex: 1,
       })
     })
 


### PR DESCRIPTION
affects: @rentpath/react-ui-ag

[Card](https://rentpath.leankit.com/card/740371798)
Based on the source of a property, zindex the map pins appropriately