### PR TITLE
fix(photo): infinite loop when no fallback

### DIFF
--- a/packages/react-ui-core/src/Photo/Photo.js
+++ b/packages/react-ui-core/src/Photo/Photo.js
@@ -109,14 +109,22 @@ export default class Photo extends PureComponent {
   fallback(e) {
     const { fallbackUrl } = this.props
 
-    if (e.target.src !== fallbackUrl) {
-      e.target.src = fallbackUrl
-      // force a re-render
+    if (e.target.src !== fallbackUrl && !this.state.error) {
+      if (fallbackUrl) {
+        // only set the src to the fallbackUrl if we have one
+        e.target.src = fallbackUrl
+      }
       // this is done in case of race condtion in terms of
       // being in limbo from ssr and client side state
       // or this happening sometime after hte component has mounted
+      // a re-render needs to be forced and it also makes this conditional
+      // get disregarded next time
       this.setState({ error: true })
+      // return this for unit testing only
+      return e
     }
+
+    return undefined
   }
 
   render() {

--- a/packages/react-ui-core/src/Photo/__tests__/Photo-test.js
+++ b/packages/react-ui-core/src/Photo/__tests__/Photo-test.js
@@ -69,6 +69,32 @@ describe('Photo', () => {
       expect(wrapper.state('error')).toEqual(true)
       expect(wrapper.find('img').prop('src')).toEqual(url)
     })
+
+    it('does not set the src when no fallbackUrl', () => {
+      let event = { target: { src: url } }
+      const wrapper = setup()
+      const instance = wrapper.instance()
+      event = instance.fallback(event)
+
+      expect(wrapper.state('error')).toEqual(true)
+      expect(event.target.src).toEqual(url)
+
+      event = instance.fallback(event)
+      expect(event).toBeUndefined()
+    })
+
+    it('does not get an an infinite loop with setting the src', () => {
+      let event = { target: { src: url } }
+      const wrapper = setup({ fallbackUrl })
+      const instance = wrapper.instance()
+      event = instance.fallback(event)
+
+      expect(wrapper.state('error')).toEqual(true)
+      expect(event.target.src).toEqual(fallbackUrl)
+
+      event = instance.fallback(event)
+      expect(event).toBeUndefined()
+    })
   })
 
   describe('src', () => {


### PR DESCRIPTION
affects: @rentpath/react-ui-core

Safeguard against infinite loop issues when onError triggers