### PR TITLE
fix(es): wrong env preset

### DIFF
--- a/packages/react-ui-ag/.babelrc
+++ b/packages/react-ui-ag/.babelrc
@@ -2,6 +2,12 @@
   "env": {
     "es": {
       "presets": [
+        ["env", {
+          "modules": false,
+          "targets": {
+            "browsers": [">0.25%", "not op_mini all"]
+          }
+        }],
         "react"
       ],
       "plugins": [

--- a/packages/react-ui-core/.babelrc
+++ b/packages/react-ui-core/.babelrc
@@ -2,6 +2,12 @@
   "env": {
     "es": {
       "presets": [
+        ["env", {
+          "modules": false,
+          "targets": {
+            "browsers": [">0.25%", "not op_mini all"]
+          }
+        }],
         "react"
       ],
       "plugins": [

--- a/packages/react-ui-rent/.babelrc
+++ b/packages/react-ui-rent/.babelrc
@@ -2,8 +2,11 @@
   "env": {
     "es": {
       "presets": [
-        ["es2015", {
-          "modules": false
+        ["env", {
+          "modules": false,
+          "targets": {
+            "browsers": [">0.25%", "not op_mini all"]
+          }
         }],
         "react"
       ],

--- a/packages/react-ui-tracking/.babelrc
+++ b/packages/react-ui-tracking/.babelrc
@@ -2,8 +2,11 @@
   "env": {
     "es": {
       "presets": [
-        ["es2015", {
-          "modules": false
+        ["env", {
+          "modules": false,
+          "targets": {
+            "browsers": [">0.25%", "not op_mini all"]
+          }
         }],
         "react"
       ],

--- a/packages/react-ui-utils/.babelrc
+++ b/packages/react-ui-utils/.babelrc
@@ -2,9 +2,12 @@
   "env": {
     "es": {
       "presets": [
-        ["es2015", {
-          "modules": false
-        }]
+        ["env", {
+          "modules": false,
+          "targets": {
+            "browsers": [">0.25%", "not op_mini all"]
+          }
+        }],
       ],
       "plugins": [
         "transform-runtime",


### PR DESCRIPTION
affects: @rentpath/react-ui-ag, @rentpath/react-ui-core, @rentpath/react-ui-rent,
@rentpath/react-ui-tracking, @rentpath/react-ui-utils

IE11 didn't like the preset for some reason still. This one works and better than what was previously here.