### PR TITLE
feat(carousel): add thumbs option

### DIFF
--- a/packages/react-ui-core/src/Carousel/Carousel.js
+++ b/packages/react-ui-core/src/Carousel/Carousel.js
@@ -29,6 +29,7 @@ export default class Carousel extends Component {
     selectedIndex: PropTypes.number,
     onSlide: PropTypes.func,
     showNav: PropTypes.bool,
+    showThumbs: PropTypes.bool,
     navigation: PropTypes.shape({
       previous: PropTypes.oneOfType([
         PropTypes.node,
@@ -60,6 +61,7 @@ export default class Carousel extends Component {
 
   static defaultProps = {
     showNav: false,
+    showThumbs: false,
     lazyLoad: false,
     theme: {},
   }
@@ -197,6 +199,7 @@ export default class Carousel extends Component {
       items,
       navigation,
       pagination,
+      showThumbs,
       ...rest
     } = this.props
 
@@ -212,11 +215,12 @@ export default class Carousel extends Component {
           items={this.items}
           renderItem={this.renderItem}
           onSlide={this.onSlide}
-          showThumbnails={false}
+          showThumbnails={showThumbs}
           showPlayButton={false}
           showFullscreenButton={false}
           startIndex={selectedIndex}
           infinite={false}
+          lastThumbnailOffset={showThumbs ? 3 : null}
           swipeThreshold={10}
           preventDefaultTouchmoveEvent
           {...rest}

--- a/packages/react-ui-core/src/Carousel/PhotoCarousel.js
+++ b/packages/react-ui-core/src/Carousel/PhotoCarousel.js
@@ -21,6 +21,7 @@ export default class PhotoCarousel extends PureComponent {
       }),
     ),
     server: PropTypes.string.isRequired,
+    showThumbs: PropTypes.bool,
     isBackgroundImage: PropTypes.bool,
     lazyLoad: PropTypes.oneOfType([
       PropTypes.bool,
@@ -74,6 +75,7 @@ export default class PhotoCarousel extends PureComponent {
       theme,
       items,
       lazyLoad,
+      showThumbs,
       ...rest
     } = this.props
 
@@ -83,6 +85,7 @@ export default class PhotoCarousel extends PureComponent {
         infinite
         renderItem={this.renderItem}
         lazyLoad={!!lazyLoad}
+        showThumbs={showThumbs}
         {...rest}
         className={classnames(
           theme.PhotoCarousel,


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/AL-35)

Creates prop that gives ability to add thumbnail previews to `react-image-gallery`.

This PR is a dependency for [this](https://github.com/rentpath/ag.js/pull/5648) PR