### PR TITLE
fix(Core/Calendar+Datepicker): update date-fns calls to use yyyy

### DIFF
--- a/packages/react-ui-core/src/DatePicker/Calendar.js
+++ b/packages/react-ui-core/src/DatePicker/Calendar.js
@@ -26,7 +26,7 @@ export default class Calendar extends PureComponent {
   }
 
   static defaultProps = {
-    dateFormat: 'MM/dd/YYYY',
+    dateFormat: 'MM/dd/yyyy',
     value: new Date(),
     minDate: new Date(),
     prevButtonLabel: String.fromCharCode(8592),
@@ -142,7 +142,7 @@ export default class Calendar extends PureComponent {
             data-tid="calendar-month"
             className={theme.Calendar_Month}
           >
-            {format(this.state.date, 'MMMM YYYY')}
+            {format(this.state.date, 'MMMM yyyy')}
           </div>
           <button
             type="button"

--- a/packages/react-ui-core/src/DatePicker/DatePicker.js
+++ b/packages/react-ui-core/src/DatePicker/DatePicker.js
@@ -23,7 +23,7 @@ export default class DatePicker extends PureComponent {
   }
 
   static defaultProps = {
-    dateFormat: 'MM/dd/YYYY',
+    dateFormat: 'MM/dd/yyyy',
     readOnly: false,
     showCalendar: false,
   }

--- a/packages/react-ui-core/src/DatePicker/__tests__/Calendar-test.js
+++ b/packages/react-ui-core/src/DatePicker/__tests__/Calendar-test.js
@@ -10,7 +10,7 @@ const theme = {
 }
 
 const Calendar = ThemedCalendar.WrappedComponent
-const DATE_FORMAT = 'MM-dd-YYYY'
+const DATE_FORMAT = 'MM-dd-yyyy'
 
 describe('Calendar', () => {
   const setup = props => (
@@ -46,7 +46,7 @@ describe('Calendar', () => {
     })
 
     it('uses custom `dateFormat` when passed', () => {
-      const dateFormat = 'YYYY-MM-dd'
+      const dateFormat = 'yyyy-MM-dd'
       const wrapper = setup({ dateFormat })
       const date = wrapper.state().date
       expect(format(date, dateFormat)).toEqual(format(new Date(), dateFormat))

--- a/packages/react-ui-core/src/DatePicker/__tests__/DatePicker-test.js
+++ b/packages/react-ui-core/src/DatePicker/__tests__/DatePicker-test.js
@@ -5,7 +5,7 @@ import DatePicker from '../DatePicker'
 import Calendar from '../Calendar'
 import Input from '../../Form/Input'
 
-const DATE_FORMAT = 'MM-dd-YYYY'
+const DATE_FORMAT = 'MM-dd-yyyy'
 
 describe('DatePicker', () => {
   const setup = props => (


### PR DESCRIPTION
Use yyyy instead of YYYY

affects: @rentpath/react-ui-core

Update date-fns calls to use yyyy to get regular years instead of
ISO week-numbering years as can be
found in this issue https://github.com/date-fns/date-fns/issues/834