### PR TITLE
fix(Filter Cards): Remove unneeded props from PriceFilterCard

### DIFF
--- a/packages/react-ui-core/src/Filters/PriceFilterCard.js
+++ b/packages/react-ui-core/src/Filters/PriceFilterCard.js
@@ -12,8 +12,6 @@ export default class PriceFilterCard extends Component {
   static propTypes = {
     className: PropTypes.string,
     theme: PropTypes.object,
-    title: PropTypes.string,
-    description: PropTypes.string,
     priceSlider: PropTypes.oneOfType([
       PropTypes.node,
       PropTypes.func,


### PR DESCRIPTION
affects: @rentpath/react-ui-core

* remove title and description props from PriceFilterCard

The props are not being used by this component. They are just getting passed through to FilterCard. FilterCard allows for more than a string, which we need, so this does nothing but prevent a warning.