### PR TITLE
fix(Impacts PhotoCarousel component): improve flexibility by separati…

### DIFF
--- a/packages/react-ui-core/src/Carousel/PhotoCarousel.js
+++ b/packages/react-ui-core/src/Carousel/PhotoCarousel.js
@@ -21,7 +21,8 @@ export default class PhotoCarousel extends PureComponent {
     ),
     server: PropTypes.string.isRequired,
     isBackgroundImage: PropTypes.bool,
-    lazyLoad: PropTypes.oneOfType([
+    lazyLoad: PropTypes.bool,
+    lazyLoadGallery: PropTypes.oneOfType([
       PropTypes.bool,
       PropTypes.object,
     ]),
@@ -29,6 +30,7 @@ export default class PhotoCarousel extends PureComponent {
 
   static defaultProps = {
     lazyLoad: false,
+    lazyLoadGallery: false,
     isBackgroundImage: false,
     theme: {},
   }
@@ -44,9 +46,9 @@ export default class PhotoCarousel extends PureComponent {
     return url || `${server}${path || id}`
   }
 
-  lazyLoad() {
-    const { lazyLoad } = this.props
-    const props = typeof lazyLoad === 'object' ? lazyLoad : {}
+  lazyLoadGallery() {
+    const { lazyLoadGallery } = this.props
+    const props = typeof lazyLoadGallery === 'object' ? lazyLoadGallery : {}
 
     return (
       <LazyLoad
@@ -76,7 +78,7 @@ export default class PhotoCarousel extends PureComponent {
       className,
       theme,
       items,
-      lazyLoad,
+      lazyLoadGallery,
       ...rest
     } = this.props
 
@@ -85,7 +87,6 @@ export default class PhotoCarousel extends PureComponent {
         items={items}
         infinite
         renderItem={this.renderItem}
-        lazyLoad={!!lazyLoad}
         {...rest}
         className={classnames(
           theme.PhotoCarousel,
@@ -99,7 +100,7 @@ export default class PhotoCarousel extends PureComponent {
     const {
       theme,
       items,
-      lazyLoad,
+      lazyLoadGallery,
     } = this.props
 
     if (!items || !items.length) {
@@ -108,6 +109,6 @@ export default class PhotoCarousel extends PureComponent {
       )
     }
 
-    return lazyLoad ? this.lazyLoad() : this.renderCarousel()
+    return lazyLoadGallery ? this.lazyLoadGallery() : this.renderCarousel()
   }
 }

--- a/packages/react-ui-core/src/Carousel/__tests__/PhotoCarousel-test.js
+++ b/packages/react-ui-core/src/Carousel/__tests__/PhotoCarousel-test.js
@@ -4,6 +4,7 @@ import LazyLoad from 'react-lazyload'
 import renderer from 'react-test-renderer'
 import theme from './mocks/theme'
 import ThemedPhotoCarousel from '../PhotoCarousel'
+import ThemedCarousel from '../Carousel'
 
 const PhotoCarousel = ThemedPhotoCarousel.WrappedComponent
 const items = [
@@ -101,9 +102,22 @@ describe('PhotoCarousel', () => {
         theme={theme}
         items={items}
         server="https://rentpath-res.cloudinary.com/"
-        lazyLoad={{ once: true, height: 400, width: 300, offset: 200 }}
+        lazyLoad
       />
     )
-    expect(wrapper.find(<LazyLoad />)).toBeTruthy()
+    expect(wrapper.find(ThemedCarousel).prop('lazyLoad')).toEqual(true)
+    expect(wrapper.find(LazyLoad).length).toBeFalsy()
+  })
+
+  it('lazyLoads gallery if required', () => {
+    const wrapper = shallow(
+      <PhotoCarousel
+        theme={theme}
+        items={items}
+        server="https://rentpath-res.cloudinary.com/"
+        lazyLoadGallery={{ once: true, height: 400, width: 300, offset: 200 }}
+      />
+    )
+    expect(wrapper.find(LazyLoad).length).toBeTruthy()
   })
 })


### PR DESCRIPTION
https://rentpath.atlassian.net/browse/TIDE-542

improve flexibility by separating lazyload props

affects: @rentpath/react-ui-core

Lazyloading the entire gallery is causing problems for us with browser back + forward navigation.
We'd rather just lazy load the photos. This change lets us do either or

BREAKING CHANGE:
Those who wish to continue lazy loading the gallery will need to use prop.lazyLoadGallery=true

ISSUES CLOSED: TIDE-542