### PR TITLE
fix(Listing.js): backwards compatibility for Listing PhotosCarousel

### DIFF
--- a/packages/react-ui-ag/src/Listings/Listing.js
+++ b/packages/react-ui-ag/src/Listings/Listing.js
@@ -40,7 +40,11 @@ export default class Listing extends Component {
     ratings: PropTypes.object,
     ctaButtons: PropTypes.arrayOf(buttonPropTypes),
     favoriteButton: buttonPropTypes,
-    lazyLoad: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
+    lazyLoad: PropTypes.bool,
+    lazyLoadGallery: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.object,
+    ]),
     isActive: PropTypes.bool,
     listingInfoComponents: PropTypes.node,
     listingTopComponents: PropTypes.node,
@@ -55,6 +59,7 @@ export default class Listing extends Component {
     listing: {},
     ratings: {},
     photos: {},
+    lazyLoadGallery: REACT_LAZYLOAD_PROP_DEFAULTS,
   }
 
   constructor(props) {
@@ -231,12 +236,9 @@ export default class Listing extends Component {
       photos,
       isActive,
       renderCustomControls,
+      lazyLoad,
+      lazyLoadGallery,
     } = this.props
-    let { lazyLoad } = this.props
-
-    if (lazyLoad && typeof lazyLoad === 'boolean') {
-      lazyLoad = typeof lazyLoad === 'boolean' ? REACT_LAZYLOAD_PROP_DEFAULTS : lazyLoad
-    }
 
     if (!isActive) {
       const { server } = photos
@@ -251,12 +253,13 @@ export default class Listing extends Component {
             showNav
             {...photos}
             lazyLoad={lazyLoad}
+            lazyLoadGallery={lazyLoadGallery}
             className={theme.Listing_Photos}
             onSlide={this.handlePhotoCarouselSlide}
             renderCustomControls={renderCustomControls}
           />
         )}
-        {this.renderPhoto(lazyLoad)}
+        {this.renderPhoto(lazyLoadGallery)}
       </React.Fragment>
     )
   }
@@ -285,6 +288,7 @@ export default class Listing extends Component {
       favoriteButton,
       isActive,
       lazyLoad,
+      lazyLoadGallery,
       listingInfoComponents,
       listingTopComponents,
       onPhotoCarouselSlide,

--- a/packages/react-ui-ag/src/Listings/MobileMapListing.js
+++ b/packages/react-ui-ag/src/Listings/MobileMapListing.js
@@ -41,7 +41,11 @@ export default class MobileMapListing extends Component {
     propertyName: PropTypes.object,
     ctaButtons: PropTypes.arrayOf(buttonPropTypes),
     favoriteButton: buttonPropTypes,
-    lazyLoad: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
+    lazyLoad: PropTypes.bool,
+    lazyLoadGallery: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.bool,
+    ]),
     isActive: PropTypes.bool,
     onPhotoCarouselSlide: PropTypes.func,
     renderCustomControls: PropTypes.func,
@@ -50,6 +54,7 @@ export default class MobileMapListing extends Component {
   static defaultProps = {
     isActive: true,
     lazyLoad: true,
+    lazyLoadGallery: REACT_LAZYLOAD_PROP_DEFAULTS,
     theme: {},
     listing: {},
     ratings: {},
@@ -201,13 +206,9 @@ export default class MobileMapListing extends Component {
       photos,
       isActive,
       renderCustomControls,
+      lazyLoad,
+      lazyLoadGallery,
     } = this.props
-
-    let { lazyLoad } = this.props
-
-    if (lazyLoad && typeof lazyLoad === 'boolean') {
-      lazyLoad = typeof lazyLoad === 'boolean' ? REACT_LAZYLOAD_PROP_DEFAULTS : lazyLoad
-    }
 
     if (!isActive) {
       const { server } = photos
@@ -222,20 +223,21 @@ export default class MobileMapListing extends Component {
             showNav
             {...photos}
             lazyLoad={lazyLoad}
+            lazyLoadGallery={lazyLoadGallery}
             className={theme.MobileMapListing_Photos}
             onSlide={this.handlePhotoCarouselSlide}
             renderCustomControls={renderCustomControls}
           />
         )}
-        {this.renderPhoto(lazyLoad)}
+        {this.renderPhoto(lazyLoadGallery)}
       </div>
     )
   }
 
-  renderPhoto(lazyLoad) {
-    if (lazyLoad) {
+  renderPhoto(lazyLoadGallery) {
+    if (lazyLoadGallery) {
       return (
-        <LazyLoad {...lazyLoad}>
+        <LazyLoad {...lazyLoadGallery}>
           <ListingComponents.Photo />
         </LazyLoad>
       )
@@ -257,6 +259,7 @@ export default class MobileMapListing extends Component {
       propertyName,
       isActive,
       lazyLoad,
+      lazyLoadGallery,
       onPhotoCarouselSlide,
       renderCustomControls,
       ...props

--- a/packages/react-ui-ag/src/Listings/SingleFamilyDesktopListing.js
+++ b/packages/react-ui-ag/src/Listings/SingleFamilyDesktopListing.js
@@ -24,10 +24,7 @@ export default class SingleFamilyDesktopListing extends Component {
     ratings: PropTypes.object,
     ctaButtons: PropTypes.arrayOf(buttonPropTypes),
     favoriteButton: buttonPropTypes,
-    lazyLoad: PropTypes.oneOfType([
-      PropTypes.object,
-      PropTypes.bool,
-    ]),
+    lazyLoad: PropTypes.bool,
     isActive: PropTypes.bool,
   }
 

--- a/packages/react-ui-ag/src/Listings/SingleFamilyMobileMapListing.js
+++ b/packages/react-ui-ag/src/Listings/SingleFamilyMobileMapListing.js
@@ -35,7 +35,8 @@ export default class SingleFamilyMobileMapListing extends Component {
     photos: PropTypes.object,
     ctaButton: buttonPropTypes,
     favoriteButton: buttonPropTypes,
-    lazyLoad: PropTypes.oneOfType([
+    lazyLoad: PropTypes.bool,
+    lazyLoadGallery: PropTypes.oneOfType([
       PropTypes.bool,
       PropTypes.object,
     ]),
@@ -48,6 +49,7 @@ export default class SingleFamilyMobileMapListing extends Component {
     ctaButton: {},
     isActive: true,
     lazyLoad: true,
+    lazyLoadGallery: REACT_LAZYLOAD_PROP_DEFAULTS,
   }
 
   shouldComponentUpdate(nextProps) {
@@ -131,12 +133,7 @@ export default class SingleFamilyMobileMapListing extends Component {
   }
 
   renderPhotoCarousel() {
-    const { theme, photos } = this.props
-    let { lazyLoad } = this.props
-
-    if (lazyLoad && typeof lazyLoad === 'boolean') {
-      lazyLoad = REACT_LAZYLOAD_PROP_DEFAULTS
-    }
+    const { theme, photos, lazyLoad, lazyLoadGallery } = this.props
 
     return (
       <div className={theme.MobileMapListing_Top}>
@@ -144,6 +141,7 @@ export default class SingleFamilyMobileMapListing extends Component {
           showNav
           {...photos}
           lazyLoad={lazyLoad}
+          lazyLoadGallery={lazyLoadGallery}
           className={theme.MobileMapListing_Photos}
         />
       </div>
@@ -161,6 +159,7 @@ export default class SingleFamilyMobileMapListing extends Component {
       favoriteButton,
       isActive,
       lazyLoad,
+      lazyLoadGallery,
       ...props
     } = this.props
 

--- a/packages/react-ui-ag/src/Listings/__tests__/DesktopListing-test.js
+++ b/packages/react-ui-ag/src/Listings/__tests__/DesktopListing-test.js
@@ -88,6 +88,7 @@ const props = {
     server: 'https://rentpath-res.cloudinary.com/',
   },
   lazyLoad: false,
+  lazyLoadGallery: false,
 }
 
 const singleFamilyProps = {

--- a/packages/react-ui-ag/src/Listings/__tests__/Listing-test.js
+++ b/packages/react-ui-ag/src/Listings/__tests__/Listing-test.js
@@ -71,6 +71,7 @@ const props = {
     server: 'https://rentpath-res.cloudinary.com/',
   },
   lazyLoad: false,
+  lazyLoadGallery: false,
   listingInfoComponents: <div>Listing Info generated component</div>,
 }
 
@@ -241,10 +242,11 @@ describe('ag/Listings/Listing', () => {
   })
 
   describe('photos', () => {
-    it('renders a component with a PhotoCarousel if active', () => {
+    it('renders a component with a PhotoCarousel with defaults if active', () => {
       const wrapper = shallow(<Listing {...props} />)
 
       expect(wrapper.find(ListingComponents.Photos)).toHaveLength(1)
+      expect(wrapper.find(ListingComponents.Photos).props()).toMatchSnapshot()
       expect(wrapper.find(ListingComponents.Photo)).toHaveLength(1)
     })
 

--- a/packages/react-ui-ag/src/Listings/__tests__/MobileMapListing-test.js
+++ b/packages/react-ui-ag/src/Listings/__tests__/MobileMapListing-test.js
@@ -72,6 +72,7 @@ const props = {
     server: 'https://rentpath-res.cloudinary.com/',
   },
   lazyLoad: false,
+  lazyLoadGallery: false,
 }
 
 describe('ag/Listing/MobileMapListing', () => {

--- a/packages/react-ui-ag/src/Listings/__tests__/SingleFamilyDesktopListing-test.js
+++ b/packages/react-ui-ag/src/Listings/__tests__/SingleFamilyDesktopListing-test.js
@@ -74,6 +74,7 @@ const props = {
     server: 'https://rentpath-res.cloudinary.com/',
   },
   lazyLoad: false,
+  lazyLoadGallery: false,
 }
 
 describe('ag/Listings/SingleFamilyDesktopListing', () => {

--- a/packages/react-ui-ag/src/Listings/__tests__/SingleFamilyMobileMapListing-test.js
+++ b/packages/react-ui-ag/src/Listings/__tests__/SingleFamilyMobileMapListing-test.js
@@ -49,6 +49,7 @@ const props = {
     server: 'https://rentpath-res.cloudinary.com/',
   },
   lazyLoad: false,
+  lazyLoadGallery: false,
 }
 
 describe('ag/Listing/SingleFamilyMobileMapListing', () => {

--- a/packages/react-ui-ag/src/Listings/__tests__/__snapshots__/Listing-test.js.snap
+++ b/packages/react-ui-ag/src/Listings/__tests__/__snapshots__/Listing-test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ag/Listings/Listing photos renders a component with a PhotoCarousel with defaults if active 1`] = `
+Object {
+  "className": undefined,
+  "lazyLoad": false,
+  "lazyLoadGallery": false,
+  "onSlide": [Function],
+  "renderCustomControls": undefined,
+  "server": "https://rentpath-res.cloudinary.com/",
+  "showNav": true,
+}
+`;


### PR DESCRIPTION
affects: @rentpath/react-ui-ag

Changes were made in https://github.com/rentpath/react-ui/pull/441 without consideration of impact to DesktopListing which uses the same component

ISSUES CLOSED: [TIDE-559](https://rentpath.atlassian.net/jira/software/projects/TIDE/boards/10?selectedIssue=TIDE-559)