### PR TITLE
fix(react-ui-core): load modal on ModalStack componentDidMount

### DIFF
--- a/packages/react-ui-core/package.json
+++ b/packages/react-ui-core/package.json
@@ -30,7 +30,8 @@
       "/node_modules/",
       "/mocks/",
       "./es",
-      "./lib"
+      "./lib",
+      "^.*__tests__/__helpers__.*"
     ]
   },
   "dependencies": {

--- a/packages/react-ui-core/src/ModalStack/ModalStack.js
+++ b/packages/react-ui-core/src/ModalStack/ModalStack.js
@@ -49,29 +49,11 @@ export default class ModalStack extends PureComponent {
 
   componentDidMount() {
     this.setupWrapperHost()
+    this.loadCurrentModal()
   }
 
   componentDidUpdate() {
-    const { currentModal: { id = null }, modalDefinitions } = this.props
-
-    if (id && !this.getModalComponent(id)) {
-      const modalDefinition = get(id)(modalDefinitions)
-      const { modals } = this.state
-
-      if (modalDefinition) {
-        this.loadModal(modalDefinition).then(modal => {
-          if (modal) {
-            this.setState({
-              currentDefinition: modalDefinition,
-              modals: {
-                ...modals,
-                [id]: modal,
-              },
-            })
-          }
-        })
-      }
-    }
+    this.loadCurrentModal()
   }
 
   @autobind
@@ -93,6 +75,30 @@ export default class ModalStack extends PureComponent {
       this.modalHost = document.createElement('section')
       this.modalHost.id = modalPortalId
       document.body.appendChild(this.modalHost)
+    }
+  }
+
+  loadCurrentModal() {
+    const { currentModal, modalDefinitions } = this.props
+    const id = currentModal && currentModal.id
+
+    if (id && !this.getModalComponent(id)) {
+      const modalDefinition = get(id)(modalDefinitions)
+      const { modals } = this.state
+
+      if (modalDefinition) {
+        this.loadModal(modalDefinition).then(modal => {
+          if (modal) {
+            this.setState({
+              currentDefinition: modalDefinition,
+              modals: {
+                ...modals,
+                [id]: modal,
+              },
+            })
+          }
+        })
+      }
     }
   }
 

--- a/packages/react-ui-core/src/ModalStack/__tests__/ModalStack-test.js
+++ b/packages/react-ui-core/src/ModalStack/__tests__/ModalStack-test.js
@@ -2,10 +2,14 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 import ModalStack from '../ModalStack'
 
+jest.mock('react-dom', () => ({
+  createPortal: node => node,
+}))
+
 const modalDefinitions = {
   1: {
     name: 'TestModal',
-    resolve: () => import('../../LeadModal/LeadModal'),
+    resolve: () => import('./__helpers__/TestModal'),
     overlay: true,
   },
 }
@@ -30,10 +34,15 @@ describe('ModalStack', () => {
       .toJSON()
     expect(snap).toMatchSnapshot()
   })
-  it('renders a modal correctly', () => {
+
+  it('renders a modal correctly', done => {
     const snap = renderer
       .create(<ModalStack currentModal={currentModal} modalDefinitions={modalDefinitions} />)
-      .toJSON()
-    expect(snap).toMatchSnapshot()
+
+    // flush JavaScript message queue, to pick up the async import() in resolve()
+    setTimeout(() => {
+      expect(snap.toJSON()).toMatchSnapshot()
+      done()
+    })
   })
 })

--- a/packages/react-ui-core/src/ModalStack/__tests__/__helpers__/TestModal.js
+++ b/packages/react-ui-core/src/ModalStack/__tests__/__helpers__/TestModal.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default () => (
+  <div>This is a test modal</div>
+)

--- a/packages/react-ui-core/src/ModalStack/__tests__/__snapshots__/ModalStack-test.js.snap
+++ b/packages/react-ui-core/src/ModalStack/__tests__/__snapshots__/ModalStack-test.js.snap
@@ -1,5 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ModalStack renders a modal correctly 1`] = `null`;
+exports[`ModalStack renders a modal correctly 1`] = `
+<div>
+  This is a test modal
+</div>
+`;
 
 exports[`ModalStack renders correctly 1`] = `null`;


### PR DESCRIPTION
affects: @rentpath/react-ui-core

[Card](https://rentpath.atlassian.net/browse/INVP-412)

If the `currentModal` prop is set on initial mount/render, the modal isn't getting loaded. It only loads when the prop is updated. This should fix that.