### PR TITLE
feat(modal): add overlayClassName prop

### DIFF
--- a/packages/react-ui-core/src/Modal/Modal.js
+++ b/packages/react-ui-core/src/Modal/Modal.js
@@ -22,6 +22,7 @@ export default class Modal extends PureComponent {
     className: PropTypes.string,
     children: PropTypes.any,
     hasOverlay: PropTypes.bool,
+    overlayClassName: PropTypes.string,
     CloseButton: PropTypes.oneOfType([
       PropTypes.func,
       PropTypes.node,
@@ -70,13 +71,14 @@ export default class Modal extends PureComponent {
   }
 
   get wrapper() {
-    const { hasOverlay } = this.props
+    const { hasOverlay, overlayClassName } = this.props
     const { isOpen } = this.state
 
     if (hasOverlay) {
       return {
         Component: Overlay,
         props: {
+          className: overlayClassName || '',
           onClick: this.overlayClose,
           isOpen,
           ...dataAttrs(this.props),

--- a/packages/react-ui-core/src/Modal/__tests__/Modal-test.js
+++ b/packages/react-ui-core/src/Modal/__tests__/Modal-test.js
@@ -51,6 +51,12 @@ describe('Modal', () => {
     expect(wrapper.childAt(0).prop('className')).toContain(className)
   })
 
+  it('adds `overlayClassName` prop to the overlay if passed in', () => {
+    const overlayClassName = 'overlayClass'
+    const wrapper = setup({ overlayClassName })
+    expect(wrapper.prop('className')).toContain(overlayClassName)
+  })
+
   it('adds Modal `theme` prop to the first child (modal)', () => {
     const wrapper = setup()
     expect(wrapper.childAt(0).prop('className')).toContain('Modal-base')


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/INVP-443)

In order to resolve INVP-441 (restoring headless e2e testing) we need to add ability to give the React-UI modal overlay a custom class. Previously, applying universal styling to the overlay in`rent-js` was disrupting some headless e2e tests.