### PR TITLE
feat(AutoSuggestField): show Selection in Input on Arrow Keys and Not Mouseover

### DIFF
--- a/packages/react-ui-core/src/AutoSuggestField/AutoSuggestField.js
+++ b/packages/react-ui-core/src/AutoSuggestField/AutoSuggestField.js
@@ -11,8 +11,8 @@ import { Menu } from '../Menu'
 import { Button } from '../Button'
 import { Field } from '../Form'
 
-const ENTER = 13
-const ESCAPE = 27
+export const ENTER = 13
+export const ESCAPE = 27
 
 @themed(/^AutoSuggestField/, { pure: true })
 export default class AutoSuggestField extends PureComponent {
@@ -39,6 +39,7 @@ export default class AutoSuggestField extends PureComponent {
     onSubmit: PropTypes.func,
     onSelection: PropTypes.func,
     onItemMouseOver: PropTypes.func,
+    onItemKeyOver: PropTypes.func,
     onInput: PropTypes.func,
     submitOnSelection: PropTypes.bool,
     visible: PropTypes.bool,
@@ -75,7 +76,7 @@ export default class AutoSuggestField extends PureComponent {
     this.state = {
       value,
       visible,
-      mousedOverSelection: null,
+      keyedOverSelection: null,
     }
   }
 
@@ -87,7 +88,7 @@ export default class AutoSuggestField extends PureComponent {
     if (this.props.value !== nextProps.value) {
       this.setState({
         value: nextProps.value,
-        mousedOverSelection: null,
+        keyedOverSelection: null,
       })
     }
   }
@@ -112,10 +113,10 @@ export default class AutoSuggestField extends PureComponent {
 
   onChange = event => {
     const { valueSelector } = this.props
-    const { mousedOverSelection } = this.state
+    const { keyedOverSelection } = this.state
 
-    if (mousedOverSelection) {
-      this.setState({ mousedOverSelection: null, value: valueSelector(mousedOverSelection) })
+    if (keyedOverSelection) {
+      this.setState({ keyedOverSelection: null, value: valueSelector(keyedOverSelection) })
     }
     const value = event.target.value
     this.setState({ value })
@@ -123,9 +124,15 @@ export default class AutoSuggestField extends PureComponent {
     this.props.onInput(value)
   }
 
+  onItemKeyOver = value => {
+    const { onItemKeyOver } = this.props
+    this.setState({ keyedOverSelection: value })
+    if (onItemKeyOver) onItemKeyOver(value)
+  }
+
   onItemMouseOver = value => {
     const { onItemMouseOver } = this.props
-    this.setState({ mousedOverSelection: value })
+
     if (onItemMouseOver) onItemMouseOver(value)
   }
 
@@ -145,11 +152,11 @@ export default class AutoSuggestField extends PureComponent {
   }
 
   get inputValue() {
-    const { value, mousedOverSelection } = this.state
+    const { value, keyedOverSelection } = this.state
     const { showSelectionInInputField, valueSelector } = this.props
 
     if (!showSelectionInInputField) return value
-    return valueSelector(mousedOverSelection) || value
+    return valueSelector(keyedOverSelection) || value
   }
 
   updateValueAndClose(value, callback = () => {}) {
@@ -230,6 +237,7 @@ export default class AutoSuggestField extends PureComponent {
       className,
       onSubmit,
       onItemMouseOver,
+      onItemKeyOver,
       onSelection,
       highlight,
       valueSelector,
@@ -264,6 +272,7 @@ export default class AutoSuggestField extends PureComponent {
               options={suggestions}
               onItemSelect={this.handleSuggestionSelection}
               onItemMouseOver={this.onItemMouseOver}
+              onItemKeyOver={this.onItemKeyOver}
             />
           </Card>
         </Dropdown>

--- a/packages/react-ui-core/src/AutoSuggestField/__tests__/AutoSuggestField-test.js
+++ b/packages/react-ui-core/src/AutoSuggestField/__tests__/AutoSuggestField-test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { mount } from 'enzyme'
 import { Menu } from '../../Menu'
-import ThemedAutoSuggestField from '../AutoSuggestField'
+import ThemedAutoSuggestField, { ENTER, ESCAPE } from '../AutoSuggestField'
 
 const AutoSuggestField = ThemedAutoSuggestField.WrappedComponent
 
@@ -91,7 +91,7 @@ describe('AutoSuggestField', () => {
       visible: true,
     })
 
-    map.keydown({ keyCode: 27 })
+    map.keydown({ keyCode: ESCAPE })
     expect(onAfterClear.mock.calls).toHaveLength(1)
   })
 
@@ -115,7 +115,7 @@ describe('AutoSuggestField', () => {
       onSubmit,
     })
 
-    map.keydown({ keyCode: 13 })
+    map.keydown({ keyCode: ENTER })
     expect(onSubmit.mock.calls).toHaveLength(1)
   })
 
@@ -198,9 +198,20 @@ describe('AutoSuggestField', () => {
       visible: true,
       showSelectionInInputField: true,
     })
-
-    const thirdListItem = wrapper.find('div[data-tid="list-item-1"]')
-    thirdListItem.simulate('mouseenter')
+    wrapper.instance().onItemKeyOver(2)
+    wrapper.update()
     expect(wrapper.find('input').prop('value')).toEqual(2)
+  })
+
+  it('does not set the input to the selected item on a mouse over if showSelectionInInputField is enabled', () => {
+    const { wrapper } = setup({
+      suggestions: [1, 2, 3],
+      visible: true,
+      showSelectionInInputField: true,
+    })
+
+    const secondListItem = wrapper.find('div[data-tid="list-item-1"]')
+    secondListItem.simulate('mouseenter')
+    expect(wrapper.find('input').prop('value')).toEqual('')
   })
 })

--- a/packages/react-ui-core/src/Menu/Menu.js
+++ b/packages/react-ui-core/src/Menu/Menu.js
@@ -24,6 +24,7 @@ export default class Menu extends PureComponent {
     ])),
     onItemSelect: PropTypes.func,
     onItemMouseOver: PropTypes.func,
+    onItemKeyOver: PropTypes.func,
     nodeType: PropTypes.string,
     listItem: PropTypes.oneOfType([
       PropTypes.node,
@@ -88,6 +89,17 @@ export default class Menu extends PureComponent {
     }
   }
 
+  onMouseEnter = index => {
+    const { onItemMouseOver } = this.props
+
+    if (index < 0 || index >= this.options.length) return
+    this.setState({
+      highlightIndex: index,
+    }, () => {
+      if (onItemMouseOver) onItemMouseOver(this.highlightedOption)
+    })
+  }
+
   get options() {
     return this.props.options || []
   }
@@ -112,17 +124,6 @@ export default class Menu extends PureComponent {
     }
   }
 
-  highlightOption = index => {
-    const { onItemMouseOver } = this.props
-
-    if (index < 0 || index >= this.options.length) return
-    this.setState({
-      highlightIndex: index,
-    }, () => {
-      if (onItemMouseOver) onItemMouseOver(this.highlightedOption)
-    })
-  }
-
   resetHighlightedIndex() {
     this.setState({
       highlightIndex: -1,
@@ -131,7 +132,7 @@ export default class Menu extends PureComponent {
   }
 
   highlightOptionAtIndex(index) {
-    const { onItemMouseOver } = this.props
+    const { onItemKeyOver } = this.props
     const indexedOptions = this.indexedOptions
 
     if (index < 0 || index >= indexedOptions.length) return
@@ -139,7 +140,7 @@ export default class Menu extends PureComponent {
       highlightIndex: indexedOptions[index].index,
       indexedOptionIndex: index,
     }, () => {
-      if (onItemMouseOver) onItemMouseOver(this.highlightedOption)
+      if (onItemKeyOver) onItemKeyOver(this.highlightedOption)
     })
   }
 
@@ -147,6 +148,7 @@ export default class Menu extends PureComponent {
     const {
       theme,
       onItemMouseOver,
+      onItemKeyOver,
       className,
       onItemSelect,
       selectedIndex,
@@ -165,7 +167,7 @@ export default class Menu extends PureComponent {
         highlightIndex={this.state.highlightIndex}
         selectedIndex={selectedIndex}
         onClick={this.handleSelection}
-        onMouseEnter={this.highlightOption}
+        onMouseEnter={this.onMouseEnter}
         {...props}
       />
     )


### PR DESCRIPTION
affects: @rentpath/react-ui-core

[Story](https://rentpath.atlassian.net/browse/HNL-378)

* add support for `onItemKeyOver` to `Menu`
* only update selection `onItemKeyOver`