### PR TITLE
feat(Carousel): add ability to override Carousel data-tid

### DIFF
--- a/packages/react-ui-core/src/Carousel/Carousel.js
+++ b/packages/react-ui-core/src/Carousel/Carousel.js
@@ -24,6 +24,7 @@ const carouselItems = PropTypes.arrayOf(
 export default class Carousel extends Component {
   static propTypes = {
     className: PropTypes.string,
+    'data-tid': PropTypes.string,
     theme: PropTypes.object,
     items: PropTypes.oneOfType([
       PropTypes.arrayOf(
@@ -68,6 +69,7 @@ export default class Carousel extends Component {
     showNav: false,
     lazyLoad: false,
     theme: {},
+    'data-tid': 'carousel',
   }
 
   componentWillReceiveProps(nextProps) {
@@ -208,6 +210,7 @@ export default class Carousel extends Component {
       items,
       navigation,
       pagination,
+      'data-tid': dataTid,
       ...rest
     } = this.props
 
@@ -217,7 +220,7 @@ export default class Carousel extends Component {
           className,
           theme.Carousel,
         )}
-        data-tid="carousel"
+        data-tid={dataTid}
       >
         <Slider
           items={this.items}

--- a/packages/react-ui-core/src/Carousel/__tests__/Carousel-test.js
+++ b/packages/react-ui-core/src/Carousel/__tests__/Carousel-test.js
@@ -36,6 +36,12 @@ describe('Carousel', () => {
     expect(wrapper.find('[data-tid="carousel"]')).toHaveLength(1)
   })
 
+  it('allows an override of the data-tid', () => {
+    const wrapper = shallow(<Carousel data-tid="foo" />)
+    expect(wrapper.find('[data-tid="foo"]')).toHaveLength(1)
+    expect(wrapper.find('[data-tid="carousel"]')).toHaveLength(0)
+  })
+
   it('renders using a custom renderItem prop', () => {
     const wrapper = mount(
       <Carousel


### PR DESCRIPTION
affects: @rentpath/react-ui-core

The Carousel component has a hard-coded data-tid, which makes it difficult to write automated tests when there are multiple Carousels on the page.