### PR TITLE
fix(core): gmap needs to use conventional props

### DIFF
--- a/packages/react-ui-core/src/Gmap/Gmap.js
+++ b/packages/react-ui-core/src/Gmap/Gmap.js
@@ -37,8 +37,6 @@ const EVENTS = {
   onZoomChanged: 'zoom_changed',
 }
 
-const EVENT_NAMES = Object.keys(EVENTS)
-
 const MAP_CONTROLS = {
   fullscreenControl: false,
   streetViewControl: false,
@@ -58,6 +56,25 @@ export class Gmap extends PureComponent {
       lat: PropTypes.number,
       lng: PropTypes.number,
     }),
+    onBoundsChanged: PropTypes.func,
+    onCenterChanged: PropTypes.func,
+    onClick: PropTypes.func,
+    onDoubleClick: PropTypes.func,
+    onDrag: PropTypes.func,
+    onDragEnd: PropTypes.func,
+    onDragStart: PropTypes.func,
+    onHeadingChanged: PropTypes.func,
+    onIdle: PropTypes.func,
+    onMaptypeIdChanged: PropTypes.func,
+    onMouseMove: PropTypes.func,
+    onMouseOut: PropTypes.func,
+    onMouseOver: PropTypes.func,
+    onProjectionChanged: PropTypes.func,
+    onResize: PropTypes.func,
+    onRightClick: PropTypes.func,
+    onTilesLoaded: PropTypes.func,
+    onTiltChanged: PropTypes.func,
+    onZoomChanged: PropTypes.func,
     zoom: PropTypes.number,
     minZoom: PropTypes.number,
     maxZoom: PropTypes.number,
@@ -233,11 +250,5 @@ export class Gmap extends PureComponent {
     )
   }
 }
-
-/* eslint-disable react/no-unused-prop-types, react/forbid-foreign-prop-types */
-EVENT_NAMES.forEach(name => {
-  Gmap.propTypes[name] = PropTypes.func
-})
-/* eslint-enable react/no-unused-prop-types, react/forbid-foreign-prop-types */
 
 export default withGoogleScript(Gmap)


### PR DESCRIPTION
affects: @rentpath/react-ui-core

We cannot strip the prop types with the current way we use dynamic props. Switching these will fix
the problem