### PR TITLE
feat(Gmap): exposes removeMarker and setupMarker functions

### DIFF
--- a/packages/react-ui-core/CHANGELOG.md
+++ b/packages/react-ui-core/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [19.3.0](https://github.com/rentpath/react-ui/compare/@rentpath/react-ui-core@19.1.3...@rentpath/react-ui-core@19.3.0) (2020-06-12)
+
+
+### Features
+
+* **core field label:** allow for ignoreAction boolean to flag data-tag_action ([3cf3cf4](https://github.com/rentpath/react-ui/commit/3cf3cf4))
+* **Gmap:** exposes removeMarker and setupMarker functions ([cfa0106](https://github.com/rentpath/react-ui/commit/cfa0106))
+
+
+
+
+
 # [19.2.0](https://github.com/rentpath/react-ui/compare/@rentpath/react-ui-core@19.1.3...@rentpath/react-ui-core@19.2.0) (2020-06-11)
 
 

--- a/packages/react-ui-core/package.json
+++ b/packages/react-ui-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rentpath/react-ui-core",
-  "version": "19.2.0",
+  "version": "19.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/rentpath/react-ui.git",

--- a/packages/react-ui-core/src/index.js
+++ b/packages/react-ui-core/src/index.js
@@ -109,6 +109,8 @@ export {
   Markers,
   OverlayView,
   FreeDrawLayer,
+  setupMarker,
+  removeMarker,
 } from './Gmap'
 
 export {


### PR DESCRIPTION
AG.js needs to access these functions to be able to swap icons on the fly without a page refresh.
AG.js PR: https://github.com/rentpath/ag.js/pull/9417/files#diff-08c6820765a001443887dd8c07d862c1R45

affects: @rentpath/react-ui-core