### PR TITLE
chore: only run tests for now

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
       run: yarn run lint
 
     - name: 'test'
-      run: yarn run test:coverage
+      run: yarn run test
 
     - name: 'configure git for lerna'
       run: |


### PR DESCRIPTION
Until I have time to fix coveralls, just run tests during the publishing workflow so that folks can deliver packages.