### PR TITLE
feat(RENT-3592): passing through event type on AutoSuggestField actions

### DIFF
--- a/packages/react-ui-core/src/AutoSuggestField/AutoSuggestField.js
+++ b/packages/react-ui-core/src/AutoSuggestField/AutoSuggestField.js
@@ -105,7 +105,7 @@ export default class AutoSuggestField extends PureComponent {
         this.handleClear()
         break
       case ENTER:
-        this.handleSubmit(this.state.value)
+        this.handleSubmit(event)
         break
       default:
     }
@@ -166,12 +166,12 @@ export default class AutoSuggestField extends PureComponent {
     }, callback)
   }
 
-  handleSubmit = () => {
-    this.props.onSubmit(this.state.value)
+  handleSubmit = event => {
+    this.props.onSubmit(this.state.value, event.type)
     this.updateValueAndClose(this.state.value)
   }
 
-  handleSuggestionSelection = value => {
+  handleSuggestionSelection = (value, _index, eventType) => {
     const {
       onSubmit,
       onSelection,
@@ -185,7 +185,7 @@ export default class AutoSuggestField extends PureComponent {
     this.updateValueAndClose(
       valueSelector(value),
       () => {
-        if (submitOnSelection) onSubmit(this.state.value)
+        if (submitOnSelection) onSubmit(this.state.value, eventType)
       }
     )
   }

--- a/packages/react-ui-core/src/Menu/Menu.js
+++ b/packages/react-ui-core/src/Menu/Menu.js
@@ -83,7 +83,7 @@ export default class Menu extends PureComponent {
         break
       case ENTER:
         event.preventDefault()
-        this.handleSelection()
+        this.handleSelection(event)
         break
       default:
     }
@@ -114,13 +114,13 @@ export default class Menu extends PureComponent {
     ), [])
   }
 
-  handleSelection = () => {
+  handleSelection = event => {
     const { onItemSelect } = this.props
 
     const option = this.highlightedOption
 
     if (onItemSelect && option && !option.disabled) {
-      onItemSelect(option, this.state.highlightIndex)
+      onItemSelect(option, this.state.highlightIndex, event.type || 'keydown')
     }
   }
 

--- a/packages/react-ui-core/src/Menu/__tests__/Menu-test.js
+++ b/packages/react-ui-core/src/Menu/__tests__/Menu-test.js
@@ -104,7 +104,7 @@ describe('Menu', () => {
 
     expect(testObject.value).toEqual(-1)
     wrapper.find('ListItem').at(1).simulate('mouseenter').simulate('click')
-    expect(onItemSelect).toHaveBeenCalledWith(options[1], 1)
+    expect(onItemSelect).toHaveBeenCalledWith(options[1], 1, 'click')
   })
 
   it('changes highlighted index on up or down keydown', () => {
@@ -132,7 +132,7 @@ describe('Menu', () => {
 
     map.keydown({ keyCode: ARROW_DOWN, preventDefault: () => {} })
     map.keydown({ keyCode: ENTER, preventDefault: () => {} })
-    expect(onItemSelect).toHaveBeenCalledWith(1, 0)
+    expect(onItemSelect).toHaveBeenCalledWith(1, 0, 'keydown')
   })
 
   it('performs on mouseover functionality ', () => {
@@ -148,7 +148,7 @@ describe('Menu', () => {
       />
     )
     wrapper.find('ListItem').at(1).simulate('mouseenter').simulate('click')
-    expect(onItemSelect).toHaveBeenCalledWith(options[1], 1)
+    expect(onItemSelect).toHaveBeenCalledWith(options[1], 1, 'click')
     expect(onItemKeyOver).not.toHaveBeenCalled()
     expect(onItemMouseOver).toHaveBeenCalled()
   })
@@ -177,7 +177,7 @@ describe('Menu', () => {
       const onItemSelect = jest.fn()
       const wrapper = mount(<Menu options={objectOptions} onItemSelect={onItemSelect} />)
       wrapper.find('ListItem').at(1).simulate('mouseenter').simulate('click')
-      expect(onItemSelect).toHaveBeenCalledWith(objectOptions[1], 1)
+      expect(onItemSelect).toHaveBeenCalledWith(objectOptions[1], 1, 'click')
     })
 
     it('passes objects that do not have label key to List', () => {


### PR DESCRIPTION
## RENT-3592 passing through event type on AutoSuggestField actions

### [Card](https://rentpath.atlassian.net/browse/RENT-3592)

affects: @rentpath/react-ui-core

In order to help dependent code to report the correct actions to google analytics we need to pass through the event type. I started out passing the actual event, but hit issues with React's handling of events as DOM elements were destroyed. This will be fixed in React 17.  I choose my approach to remain backwards compatable.
