### PR TITLE
chore(clsx): replace classnames with clsx

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project uses [commitizen](https://github.com/commitizen/cz-cli).  This allo
 
 Anything that is included in the `BREAKING_CHANGES` section of the prompt will automatically bump the package version for the repo to a major version.
 
-Also, please keep in mind your `scope` should be what you were working on. It should be something like `form` or `listing` or `photo`.  The short description of change should be precise as it's what you will see in the CHANGELOG (along with the scope).  
+Also, please keep in mind your `scope` should be what you were working on. It should be something like `form` or `listing` or `photo`.  The short description of change should be precise as it's what you will see in the CHANGELOG (along with the scope).
 
 ## Working Locally
 
@@ -35,14 +35,14 @@ Follow these steps to work with your local files instead of the published versio
 
 Many react components use [react-themed](https://github.com/rentpath/react-themed) when needed. Please read the documenation if you're not familiar with it.
 
-### CEM (BEM) syntax and classnames
+### CEM (BEM) syntax and clsx
 
 For information on BEM, please [read](http://getbem.com/introduction/)
 
 All components should follow a CEM (Component Element Modifier) syntax.  The top level element in your component should usually have the component name as the className. Every child should use the Component className as a prefix _unless_ you are importing another component that has already been themed. A good rule of thumb to use:
 
 ```
-import classnames from 'classnames'
+import clsx from 'clsx'
 import Button from './Button'
 
 class SomeComponent extends PureComponent {
@@ -51,7 +51,7 @@ class SomeComponent extends PureComponent {
 
     return (
       <div
-        className={classnames(
+        className={clsx(
           theme.SomeComponent,
           className,
         )}
@@ -65,7 +65,7 @@ class SomeComponent extends PureComponent {
 }
 ```
 
-Notice the above.  The top level component uses [classnames](https://github.com/JedWatson/classnames) to include the base class (`SomeComponent`) and the ability to pass in a custom `className` prop.  The first `<Button>` does not get a className because it is already themed.  The second `<Button className={theme[Button-red']}>` component takes in a className with a modifier that gets appended to button the same way the top level component uses classnames.
+Notice the above.  The top level component uses [clsx](https://github.com/lukeed/clsx) to include the base class (`SomeComponent`) and the ability to pass in a custom `className` prop.  The first `<Button>` does not get a className because it is already themed.  The second `<Button className={theme[Button-red']}>` component takes in a className with a modifier that gets appended to button the same way the top level component uses clsx.
 
 #### Naming conventions
 ```

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   "dependencies": {
     "@babel/runtime": "^7.1.5",
     "@rentpath/react-themed": "^4.1.4",
-    "classnames": "^2.2.6",
+    "clsx": "^1.1.1",
     "form-serialize": "0.7.2"
   },
   "peerDependencies": {

--- a/packages/react-ui-core/package.json
+++ b/packages/react-ui-core/package.json
@@ -53,7 +53,7 @@
   },
   "peerDependencies": {
     "@rentpath/react-themed": "^4.1.0",
-    "classnames": "^2.2.6",
+    "clsx": "*",
     "date-fns": "^2.0.0",
     "lodash": "^4.17.10",
     "prop-types": "15.7.2",

--- a/packages/react-ui-core/src/AutoSuggestField/AutoSuggestField.js
+++ b/packages/react-ui-core/src/AutoSuggestField/AutoSuggestField.js
@@ -3,7 +3,7 @@ import { parseArgs } from '@rentpath/react-ui-utils'
 import capitalize from 'lodash/capitalize'
 import PropTypes from 'prop-types'
 import themed from '@rentpath/react-themed'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import { Dropdown } from '../Dropdown'
 import { Card } from '../Card'
 import { Highlighter } from '../Highlighter'
@@ -253,7 +253,7 @@ export default class AutoSuggestField extends PureComponent {
 
     return (
       <div
-        className={classnames(
+        className={clsx(
           theme.AutoSuggestField,
           className
         )}

--- a/packages/react-ui-core/src/Button/ApplyButton.js
+++ b/packages/react-ui-core/src/Button/ApplyButton.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import themed from '@rentpath/react-themed'
 import autobind from 'autobind-decorator'
 import Button from './Button'
@@ -43,7 +43,7 @@ export default class ApplyButton extends PureComponent {
 
     return (
       <Button
-        className={classnames(
+        className={clsx(
           theme.ApplyButton,
           className,
         )}

--- a/packages/react-ui-core/src/Button/Button.js
+++ b/packages/react-ui-core/src/Button/Button.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import themed from '@rentpath/react-themed'
 
 @themed(/^Button/, {
@@ -38,7 +38,7 @@ export default class Button extends Component {
         {...props}
         ref={componentRef}
         className={
-          classnames(
+          clsx(
             className,
             theme.Button,
             color && theme[`Button-${color}`],

--- a/packages/react-ui-core/src/Button/CancelButton.js
+++ b/packages/react-ui-core/src/Button/CancelButton.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import themed from '@rentpath/react-themed'
 import autobind from 'autobind-decorator'
 import Button from './Button'
@@ -42,7 +42,7 @@ export default class CancelButton extends PureComponent {
 
     return (
       <Button
-        className={classnames(
+        className={clsx(
           theme.CancelButton,
           className,
         )}

--- a/packages/react-ui-core/src/Button/ToggleButton.js
+++ b/packages/react-ui-core/src/Button/ToggleButton.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import themed from '@rentpath/react-themed'
 import autobind from 'autobind-decorator'
 import Button from './Button'
@@ -66,7 +66,7 @@ export default class ToggleButton extends Component {
     return (
       <Button
         onClick={this.toggle}
-        className={classnames(
+        className={clsx(
           theme.ToggleButton,
           className,
           theme[this.state.value ? 'ToggleButton-on' : 'ToggleButton-off'],

--- a/packages/react-ui-core/src/Card/Card.js
+++ b/packages/react-ui-core/src/Card/Card.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import cn from 'classnames'
+import clsx from 'clsx'
 import themed from '@rentpath/react-themed'
 
 @themed('*', { pure: true })
@@ -25,7 +25,7 @@ export default class Card extends PureComponent {
 
     return (
       <div
-        className={cn(
+        className={clsx(
           theme.Card,
           className,
         )}

--- a/packages/react-ui-core/src/Carousel/Carousel.js
+++ b/packages/react-ui-core/src/Carousel/Carousel.js
@@ -1,7 +1,7 @@
 import React, { Component, createElement } from 'react'
 import PropTypes from 'prop-types'
 import themed from '@rentpath/react-themed'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import autobind from 'autobind-decorator'
 import Slider from 'react-image-gallery'
 import { forceCheck } from 'react-lazyload'
@@ -213,7 +213,7 @@ export default class Carousel extends Component {
 
     return (
       <div
-        className={classnames(
+        className={clsx(
           className,
           theme.Carousel,
         )}

--- a/packages/react-ui-core/src/Carousel/CarouselNavigation.js
+++ b/packages/react-ui-core/src/Carousel/CarouselNavigation.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import themed from '@rentpath/react-themed'
 import { Button } from '../Button'
 
@@ -38,7 +38,7 @@ export default class CarouselNavigation extends PureComponent {
       <Button
         data-tid={`carousel-navigation-${direction}`}
         data-tag_item={this.tagItem}
-        className={classnames(
+        className={clsx(
           className,
           theme.CarouselNavigation,
           theme[`CarouselNavigation-${direction}`]

--- a/packages/react-ui-core/src/Carousel/PhotoCarousel.js
+++ b/packages/react-ui-core/src/Carousel/PhotoCarousel.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import themed from '@rentpath/react-themed'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import LazyLoad from 'react-lazyload'
 import autobind from 'autobind-decorator'
 import { Photo, BackgroundPhoto } from '../Photo'
@@ -95,7 +95,7 @@ export default class PhotoCarousel extends PureComponent {
         infinite
         renderItem={this.renderItem}
         {...rest}
-        className={classnames(
+        className={clsx(
           theme.PhotoCarousel,
           className,
         )}

--- a/packages/react-ui-core/src/Collapsible/Collapsible.js
+++ b/packages/react-ui-core/src/Collapsible/Collapsible.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import themed from '@rentpath/react-themed'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import { Button } from '../Button'
 
 const type = PropTypes.oneOfType([
@@ -72,7 +72,7 @@ export default class Collapsible extends Component {
 
     return (
       <div
-        className={classnames(
+        className={clsx(
           className,
           theme.Collapsible,
         )}
@@ -81,7 +81,7 @@ export default class Collapsible extends Component {
         {nonshowableItems && [
           <div
             key="collapsible-toggle"
-            className={classnames(
+            className={clsx(
               theme.Collapsible_Items,
               theme[`Collapsible_Items-${toggle}`]
             )}
@@ -91,7 +91,7 @@ export default class Collapsible extends Component {
           <Button
             key="collapsible-button"
             onClick={this.handleClick}
-            className={classnames(
+            className={clsx(
               theme[`Button-${toggle}`],
               align && theme[`Button-${align}`],
             )}

--- a/packages/react-ui-core/src/Counter/Counter.js
+++ b/packages/react-ui-core/src/Counter/Counter.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import themed from '@rentpath/react-themed'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import { Text } from '../Text'
 
 @themed(/^(Counter|Label|Text)/, {
@@ -105,7 +105,7 @@ export default class Counter extends PureComponent {
     return (
       <div
         className={
-          classnames(
+          clsx(
             theme.Counter,
             className
           )}
@@ -117,7 +117,7 @@ export default class Counter extends PureComponent {
             role="presentation"
             onClick={this.decrement}
             className={
-              classnames(
+              clsx(
                 theme.Counter_Button,
                 theme.Counter_Decrement,
               )
@@ -133,7 +133,7 @@ export default class Counter extends PureComponent {
             role="presentation"
             onClick={this.increment}
             className={
-              classnames(
+              clsx(
                 theme.Counter_Button,
                 theme.Counter_Increment,
               )

--- a/packages/react-ui-core/src/DatePicker/Calendar.js
+++ b/packages/react-ui-core/src/DatePicker/Calendar.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import themed from '@rentpath/react-themed'
 import autobind from 'autobind-decorator'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import isEqual from 'date-fns/isEqual'
 import format from 'date-fns/format'
 import addMonths from 'date-fns/addMonths'
@@ -125,7 +125,7 @@ export default class Calendar extends PureComponent {
 
       daysOfMonth.push(
         <button
-          className={classnames(
+          className={clsx(
             theme.Calendar_Date,
             !currentMonth && theme['Calendar_Date-notCurrentMonth'],
             active && theme['Calendar_Date-active'],
@@ -165,7 +165,7 @@ export default class Calendar extends PureComponent {
 
     return (
       <div
-        className={classnames(
+        className={clsx(
           theme.Calendar,
           className,
         )}
@@ -176,7 +176,7 @@ export default class Calendar extends PureComponent {
           <button
             type="button"
             data-tid="calendar-previous"
-            className={classnames(
+            className={clsx(
               theme.Calendar_Navigation,
               theme['Calendar_Navigation-previous'],
             )}
@@ -195,7 +195,7 @@ export default class Calendar extends PureComponent {
           <button
             type="button"
             data-tid="calendar-next"
-            className={classnames(
+            className={clsx(
               theme.Calendar_Navigation,
               theme['Calendar_Navigation-next'],
             )}

--- a/packages/react-ui-core/src/Drawer/Drawer.js
+++ b/packages/react-ui-core/src/Drawer/Drawer.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react'
 import themed from '@rentpath/react-themed'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import autobind from 'autobind-decorator'
 import { ToggleButton } from '../Button'
 
@@ -71,7 +71,7 @@ export default class Drawer extends PureComponent {
 
     return (
       <div
-        className={classnames(
+        className={clsx(
           theme.Drawer,
           theme[visible ? 'Drawer-on' : 'Drawer-off'],
           className,
@@ -80,7 +80,7 @@ export default class Drawer extends PureComponent {
         data-tid="drawer"
       >
         <ToggleButton
-          className={classnames(
+          className={clsx(
             theme[visible ? 'Drawer-Button-on' : 'Drawer-Button-off'],
           )}
           theme={theme}

--- a/packages/react-ui-core/src/Dropdown/Dropdown.js
+++ b/packages/react-ui-core/src/Dropdown/Dropdown.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types'
 import autobind from 'autobind-decorator'
 import { parseArgs } from '@rentpath/react-ui-utils'
 import themed from '@rentpath/react-themed'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import DropdownAnchor from './DropdownAnchor'
 
 @themed(/^Dropdown/)
@@ -118,7 +118,7 @@ export default class Dropdown extends Component {
     return (
       <div
         ref={ref => { this.dropdown = ref }}
-        className={classnames(
+        className={clsx(
           theme.Dropdown,
           className,
           theme[`Dropdown-${visible ? 'expand' : 'collapse'}`]

--- a/packages/react-ui-core/src/Dropdown/DropdownAnchor.js
+++ b/packages/react-ui-core/src/Dropdown/DropdownAnchor.js
@@ -1,7 +1,7 @@
 import { createElement, PureComponent } from 'react'
 import { parseArgs } from '@rentpath/react-ui-utils'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import themed from '@rentpath/react-themed'
 import { Button } from '../Button'
 
@@ -44,7 +44,7 @@ export default class DropdownAnchor extends PureComponent {
 
     return createElement(...parseArgs(anchor, Button, {
       'data-tid': 'dropdown-anchor',
-      className: classnames(
+      className: clsx(
         className,
         theme.DropdownAnchor,
         theme[`DropdownAnchor-${visible ? 'expand' : 'collapse'}`]

--- a/packages/react-ui-core/src/Filters/FilterCard.js
+++ b/packages/react-ui-core/src/Filters/FilterCard.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import themed from '@rentpath/react-themed'
 import { parseArgs } from '@rentpath/react-ui-utils'
 import { Title } from '../Title'
@@ -55,7 +55,7 @@ export default class FilterCard extends PureComponent {
 
     return (
       <Card
-        className={classnames(
+        className={clsx(
           theme.FilterCard,
           className,
         )}

--- a/packages/react-ui-core/src/Filters/PriceFilterCard.js
+++ b/packages/react-ui-core/src/Filters/PriceFilterCard.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import classname from 'classnames'
+import clsx from 'clsx'
 import themed from '@rentpath/react-themed'
 import autobind from 'autobind-decorator'
 import { parseArgs } from '@rentpath/react-ui-utils'
@@ -63,7 +63,7 @@ export default class PriceFilterCard extends Component {
 
     return (
       <FilterCard
-        className={classname(
+        className={clsx(
           theme.PriceFilterCard,
           className,
           !this.state.value && theme['PriceFilterCard-noValue']

--- a/packages/react-ui-core/src/Filters/RadioGroupFilterCard.js
+++ b/packages/react-ui-core/src/Filters/RadioGroupFilterCard.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import themed from '@rentpath/react-themed'
 import isEqual from 'lodash/isEqual'
 import autobind from 'autobind-decorator'
@@ -70,7 +70,7 @@ export default class RadioGroupFilterCard extends Component {
 
     return (
       <FilterCard
-        className={classnames(
+        className={clsx(
           theme.RadioGroupFilterCard,
           className,
           !this.state.value && theme['RadioGroupFilterCard-noValue']

--- a/packages/react-ui-core/src/Form/Field.js
+++ b/packages/react-ui-core/src/Form/Field.js
@@ -1,7 +1,7 @@
 import React, { Component, createElement } from 'react'
 import PropTypes from 'prop-types'
 import themed from '@rentpath/react-themed'
-import classNames from 'classnames'
+import clsx from 'clsx'
 import { parseArgs, randomId } from '@rentpath/react-ui-utils'
 import { Text } from '../Text'
 import Label from './Label'
@@ -225,7 +225,7 @@ export default class Field extends Component {
       FieldType,
       fieldProps,
     ] = parseArgs(container, null, {
-      className: classNames(
+      className: clsx(
         className,
         theme.Field,
         theme[`Field-${type}`],

--- a/packages/react-ui-core/src/Form/FieldSet.js
+++ b/packages/react-ui-core/src/Form/FieldSet.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import themed from '@rentpath/react-themed'
-import classnames from 'classnames'
+import clsx from 'clsx'
 
 @themed(/^FieldSet/, {
   pure: true,
@@ -32,7 +32,7 @@ export default class FieldSet extends PureComponent {
     return (
       <fieldset
         {...props}
-        className={classnames(
+        className={clsx(
           className,
           theme.FieldSet,
           variant && theme[`FieldSet-${variant}`],

--- a/packages/react-ui-core/src/Form/Form.js
+++ b/packages/react-ui-core/src/Form/Form.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import themed from '@rentpath/react-themed'
-import classNames from 'classnames'
+import clsx from 'clsx'
 import serializeForm from 'form-serialize'
 
 @themed(['Form'], { pure: true })
@@ -89,7 +89,7 @@ export default class Form extends Component {
         data-tid="form"
         {...props}
         onSubmit={this.onSubmit}
-        className={classNames(
+        className={clsx(
           className,
           theme.Form,
         )}

--- a/packages/react-ui-core/src/Form/Input.js
+++ b/packages/react-ui-core/src/Form/Input.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import themed from '@rentpath/react-themed'
 import InputMask from 'react-input-mask'
 import autobind from 'autobind-decorator'
@@ -142,7 +142,7 @@ export default class Input extends Component {
 
     return (
       <InputComponent
-        className={classnames(
+        className={clsx(
           className,
           theme.Input,
           theme[`Input-${props.type}`],

--- a/packages/react-ui-core/src/Form/Label.js
+++ b/packages/react-ui-core/src/Form/Label.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import themed from '@rentpath/react-themed'
-import classNames from 'classnames'
+import clsx from 'clsx'
 
 @themed(/^Label/, {
   pure: true,
@@ -29,7 +29,7 @@ export default class Label extends Component {
       ...props
     } = this.props
 
-    const classnames = classNames(
+    const classNames = clsx(
       className,
       theme.Label,
       variant && theme[`Label-${variant}`]
@@ -40,7 +40,7 @@ export default class Label extends Component {
       <label
         data-tid="label"
         {...props}
-        className={classnames}
+        className={classNames}
       >
         {text}
         {children}

--- a/packages/react-ui-core/src/Form/RadioButton.js
+++ b/packages/react-ui-core/src/Form/RadioButton.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import themed from '@rentpath/react-themed'
 import Field from './Field'
 
@@ -32,7 +32,7 @@ export default class RadioButton extends PureComponent {
 
       return (
         <Field
-          className={classnames(
+          className={clsx(
             className,
             theme.RadioButton,
             this.props.checked && theme['RadioButton-checked'],

--- a/packages/react-ui-core/src/Form/RadioGroup.js
+++ b/packages/react-ui-core/src/Form/RadioGroup.js
@@ -1,7 +1,7 @@
 import React, { PureComponent, createElement } from 'react'
 import PropTypes from 'prop-types'
 import autobind from 'autobind-decorator'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import themed from '@rentpath/react-themed'
 import { parseArgs, randomId } from '@rentpath/react-ui-utils'
 import pick from 'lodash/pick'
@@ -198,7 +198,7 @@ export default class RadioGroup extends PureComponent {
 
     return (
       <div
-        className={classnames(
+        className={clsx(
           className,
           theme.RadioGroup,
           theme[`Field-${this.props.name}`],

--- a/packages/react-ui-core/src/Form/RangeSlider.js
+++ b/packages/react-ui-core/src/Form/RangeSlider.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import InputRange from 'react-input-range'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import omit from 'lodash/omit'
 import isEqual from 'lodash/isEqual'
 import themed from '@rentpath/react-themed'
@@ -67,7 +67,7 @@ export default class RangeSlider extends PureComponent {
 
     return (
       <div className={
-        classnames(
+        clsx(
           theme.RangeSlider,
           className,
           variant && theme[`RangeSlider-${variant}`],

--- a/packages/react-ui-core/src/Form/Select.js
+++ b/packages/react-ui-core/src/Form/Select.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import classNames from 'classnames'
+import clsx from 'clsx'
 import themed from '@rentpath/react-themed'
 import autobind from 'autobind-decorator'
 
@@ -99,7 +99,7 @@ export default class Select extends Component {
       <select
         {...props}
         {...this.controlledProps}
-        className={classNames(
+        className={clsx(
           className,
           theme.Select,
           variant && theme[`Select-${variant}`],

--- a/packages/react-ui-core/src/Form/TermsOfService.js
+++ b/packages/react-ui-core/src/Form/TermsOfService.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import themed from '@rentpath/react-themed'
 import { Text } from '../Text'
 
@@ -30,7 +30,7 @@ export default class TermsOfService extends PureComponent {
 
     return (
       <Text
-        className={classnames(
+        className={clsx(
           className,
           theme.TermsOfService,
         )}

--- a/packages/react-ui-core/src/Form/Textarea.js
+++ b/packages/react-ui-core/src/Form/Textarea.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import classNames from 'classnames'
+import clsx from 'clsx'
 import themed from '@rentpath/react-themed'
 
 @themed(/^Textarea/, { pure: true })
@@ -26,7 +26,7 @@ export default class Textarea extends Component {
     return (
       <textarea
         {...props}
-        className={classNames(
+        className={clsx(
           className,
           theme.Textarea,
           variant && theme[`Textarea-${variant}`],

--- a/packages/react-ui-core/src/Form/validateField.js
+++ b/packages/react-ui-core/src/Form/validateField.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { themed } from '@rentpath/react-themed'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import { componentName } from '@rentpath/react-ui-utils'
 
 const validateField = Component => {
@@ -13,7 +13,7 @@ const validateField = Component => {
     validFieldIcon,
     ...props
   }) => (
-    <div className={classnames(theme.ValidatedField, className)}>
+    <div className={clsx(theme.ValidatedField, className)}>
       <Component
         theme={theme}
         {...props}

--- a/packages/react-ui-core/src/Gmap/Gmap.js
+++ b/packages/react-ui-core/src/Gmap/Gmap.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import themed from '@rentpath/react-themed'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import startsWith from 'lodash/startsWith'
 import pickBy from 'lodash/pickBy'
 import { GmapInteraction } from './GmapInteraction'
@@ -238,7 +238,7 @@ export class Gmap extends PureComponent {
     return (
       <div
         ref={this.googleMap}
-        className={classnames(
+        className={clsx(
           theme.Gmap,
           className,
         )}

--- a/packages/react-ui-core/src/Gmap/GmapSpinner.js
+++ b/packages/react-ui-core/src/Gmap/GmapSpinner.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import themed from '@rentpath/react-themed'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import BounceLoader from './spinners/BounceLoader'
 
 @themed(['Gmap_Spinner'], { pure: true })
@@ -59,7 +59,7 @@ export default class GmapSpinner extends PureComponent {
     } = this.props
 
     return (
-      <div className={classnames(
+      <div className={clsx(
         className,
         theme.Gmap_Spinner,
       )}

--- a/packages/react-ui-core/src/Gmap/OverlayView.js
+++ b/packages/react-ui-core/src/Gmap/OverlayView.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react'
 import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
 import themed from '@rentpath/react-themed'
-import classnames from 'classnames'
+import clsx from 'clsx'
 
 @themed(/^Gmap_OverlayView/, { pure: true })
 export default class OverlayView extends PureComponent {
@@ -44,7 +44,7 @@ export default class OverlayView extends PureComponent {
     }
 
     if (this.container && (theme !== prevProps.theme || className !== prevProps.className)) {
-      this.container.className = classnames(className, theme.Gmap_OverlayView)
+      this.container.className = clsx(className, theme.Gmap_OverlayView)
     }
   }
 
@@ -91,7 +91,7 @@ export default class OverlayView extends PureComponent {
     this.container.style.position = 'absolute'
     this.container.style.display = 'none'
     this.container.style.cursor = 'auto'
-    this.container.className = classnames(className, theme.Gmap_OverlayView)
+    this.container.className = clsx(className, theme.Gmap_OverlayView)
     if (preventBubbleEvents) this.preventBubbleEvents()
 
     this.overlay = new window.google.maps.OverlayView()

--- a/packages/react-ui-core/src/Highlighter/Highlighter.js
+++ b/packages/react-ui-core/src/Highlighter/Highlighter.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import themed from '@rentpath/react-themed'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import { randomId } from '@rentpath/react-ui-utils'
 
 @themed(/^Highlighter/)
@@ -54,7 +54,7 @@ export default class Highlighter extends PureComponent {
       return (
         <span
           data-tid={`highlighter-match-${index}`}
-          className={classnames(
+          className={clsx(
             theme['Highlighter-Match'],
             className,
           )}
@@ -80,7 +80,7 @@ export default class Highlighter extends PureComponent {
 
     return renderer(
       <div
-        className={classnames(
+        className={clsx(
           theme.Highlighter,
           className,
         )}

--- a/packages/react-ui-core/src/LeadForm/LeadForm.js
+++ b/packages/react-ui-core/src/LeadForm/LeadForm.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import themed from '@rentpath/react-themed'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import isEqual from 'lodash/isEqual'
 import { randomId } from '@rentpath/react-ui-utils'
 import SubmitButton from './SubmitButton'
@@ -118,7 +118,7 @@ export default class LeadForm extends Component {
 
     return (
       <Form
-        className={classnames(
+        className={clsx(
           theme.LeadForm,
           className,
         )}

--- a/packages/react-ui-core/src/List/List.js
+++ b/packages/react-ui-core/src/List/List.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import isEqual from 'lodash/isEqual'
-import cn from 'classnames'
+import clsx from 'clsx'
 import { randomId, parseArgs } from '@rentpath/react-ui-utils'
 import themed from '@rentpath/react-themed'
 import DefaultListItem from './ListItem'
@@ -88,7 +88,7 @@ export default class List extends PureComponent {
 
     return (
       <NodeType
-        className={cn(
+        className={clsx(
           theme.List,
           orientation && theme[`List-${orientation}`],
           className,

--- a/packages/react-ui-core/src/List/ListItem.js
+++ b/packages/react-ui-core/src/List/ListItem.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import cn from 'classnames'
+import clsx from 'clsx'
 import autobind from 'autobind-decorator'
 import themed from '@rentpath/react-themed'
 
@@ -52,7 +52,7 @@ export default class ListItem extends PureComponent {
 
     return (
       <NodeType
-        className={cn(
+        className={clsx(
           theme.ListItem,
           className,
           highlight && theme['ListItem-highlight'],

--- a/packages/react-ui-core/src/Menu/DropdownMenu.js
+++ b/packages/react-ui-core/src/Menu/DropdownMenu.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import autobind from 'autobind-decorator'
 import themed from '@rentpath/react-themed'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import isEqual from 'lodash/isEqual'
 import { Dropdown } from '../Dropdown'
 import MenuWrapper from './MenuWrapper'
@@ -98,7 +98,7 @@ export default class DropdownMenu extends Component {
 
     return (
       <Dropdown
-        className={classnames(className, theme.DropdownMenu)}
+        className={clsx(className, theme.DropdownMenu)}
         anchorField={{ children: this.renderAnchorFieldText() }}
         {...props}
       >

--- a/packages/react-ui-core/src/Menu/Menu.js
+++ b/packages/react-ui-core/src/Menu/Menu.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react'
 import isEqual from 'lodash/isEqual'
 import PropTypes from 'prop-types'
 import themed from '@rentpath/react-themed'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import { List } from '../List'
 
 export const ENTER = 13
@@ -159,7 +159,7 @@ export default class Menu extends PureComponent {
     return (
       <List
         role="button"
-        className={classnames(
+        className={clsx(
           className,
           theme.Menu
         )}

--- a/packages/react-ui-core/src/Modal/Modal.js
+++ b/packages/react-ui-core/src/Modal/Modal.js
@@ -2,7 +2,7 @@ import React, { PureComponent, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import { parseArgs } from '@rentpath/react-ui-utils'
 import themed from '@rentpath/react-themed'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import autobind from 'autobind-decorator'
 import Overlay from './Overlay'
 import ModalCloseButton from './ModalCloseButton'
@@ -113,7 +113,7 @@ export default class Modal extends PureComponent {
         <div
           data-tid="modal"
           {...props}
-          className={classnames(
+          className={clsx(
             className,
             theme[`Modal-${isOpen ? 'open' : 'close'}`],
             theme.Modal

--- a/packages/react-ui-core/src/Modal/ModalCloseButton.js
+++ b/packages/react-ui-core/src/Modal/ModalCloseButton.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import themed from '@rentpath/react-themed'
-import classnames from 'classnames'
+import clsx from 'clsx'
 
 @themed(/^CloseButton/, {
   pure: true,
@@ -28,7 +28,7 @@ export default class CloseButton extends PureComponent {
 
     return (
       <div
-        className={classnames(
+        className={clsx(
           className,
           theme.CloseButton
         )}

--- a/packages/react-ui-core/src/Modal/Overlay.js
+++ b/packages/react-ui-core/src/Modal/Overlay.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import themed from '@rentpath/react-themed'
 import autobind from 'autobind-decorator'
 
@@ -74,7 +74,7 @@ export default class Overlay extends PureComponent {
         onMouseDown={this.handleMouseDown}
         onMouseUp={this.handleMouseUp}
         onClick={this.handleClick}
-        className={classnames(
+        className={clsx(
           className,
           theme.Overlay,
           theme[`Overlay-${isOpen ? 'open' : 'close'}`],

--- a/packages/react-ui-core/src/Photo/BackgroundPhoto.js
+++ b/packages/react-ui-core/src/Photo/BackgroundPhoto.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import pipe from 'lodash/fp/pipe'
 import filter from 'lodash/fp/filter'
 import map from 'lodash/fp/map'
@@ -47,7 +47,7 @@ export default class BackgroundPhoto extends PureComponent {
         style={{
           backgroundImage: backgroundUrl(url, fallbackUrl),
         }}
-        className={classnames(
+        className={clsx(
           className,
           theme.BackgroundPhoto
         )}

--- a/packages/react-ui-core/src/Photo/Photo.js
+++ b/packages/react-ui-core/src/Photo/Photo.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import autobind from 'autobind-decorator'
 import themed from '@rentpath/react-themed'
 
@@ -166,7 +166,7 @@ export default class Photo extends PureComponent {
         alt={alt}
         data-tid="photo"
         ref={this.img}
-        className={classnames(
+        className={clsx(
           className,
           theme.Photo,
           isFallback && theme['Photo-error'],

--- a/packages/react-ui-core/src/Ratings/RatingBar.js
+++ b/packages/react-ui-core/src/Ratings/RatingBar.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import themed from '@rentpath/react-themed'
-import classnames from 'classnames'
+import clsx from 'clsx'
 
 @themed(/^(RatingBar|Label)/, {
   pure: true,
@@ -57,7 +57,7 @@ export default class RatingBar extends PureComponent {
     return (
       <div
         className={
-          classnames(
+          clsx(
             theme.RatingBar,
             className,
           )

--- a/packages/react-ui-core/src/Text/Text.js
+++ b/packages/react-ui-core/src/Text/Text.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import themed from '@rentpath/react-themed'
 
 @themed(/^Text/, {
@@ -31,7 +31,7 @@ export default class Text extends PureComponent {
         data-tid="text"
         {...props}
         className={
-          classnames(
+          clsx(
             className,
             theme.Text,
           )

--- a/packages/react-ui-core/src/Title/Title.js
+++ b/packages/react-ui-core/src/Title/Title.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import themed from '@rentpath/react-themed'
 
 @themed('*', {
@@ -30,7 +30,7 @@ export default class Title extends PureComponent {
 
     return (
       <NodeType
-        className={classnames(
+        className={clsx(
           theme.Title,
           className,
         )}

--- a/packages/react-ui-utils/package.json
+++ b/packages/react-ui-utils/package.json
@@ -35,6 +35,6 @@
     ]
   },
   "peerDependencies": {
-    "classnames": "^2.2.6"
+    "clsx": "*"
   }
 }

--- a/packages/react-ui-utils/src/composeProps.js
+++ b/packages/react-ui-utils/src/composeProps.js
@@ -1,4 +1,4 @@
-import classNames from 'classnames'
+import clsx from 'clsx'
 
 /**
  * Merges react component props, using regular
@@ -31,7 +31,7 @@ export default (target, ...items) => {
   }, target)
 
   if (classnames.length > 1) {
-    target.className = classNames(...classnames) // eslint-disable-line no-param-reassign
+    target.className = clsx(...classnames) // eslint-disable-line no-param-reassign
   }
 
   return target

--- a/stories/core/Carousel.js
+++ b/stories/core/Carousel.js
@@ -1,11 +1,11 @@
 import React from 'react'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import { Carousel, PhotoCarousel } from 'react-ui-core/src'
 import StoryBookTheme from '../theme/Storybook.css'
 
 const Item = ({ children }) => ( // eslint-disable-line react/prop-types
   <div
-    className={classnames(
+    className={clsx(
       StoryBookTheme.Story_CarouselItem,
       StoryBookTheme['Story_CarouselItem-center'],
     )}

--- a/stories/core/ExampleComponents/DynamicDropdownExample.js
+++ b/stories/core/ExampleComponents/DynamicDropdownExample.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import themed from '@rentpath/react-themed'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import {
   Dropdown,
   Menu,
@@ -22,6 +22,7 @@ export default class DynamicDropdownExample extends PureComponent {
 
   static defaultProps = {
     theme: {},
+
     buttonText: 'choose',
   }
 
@@ -40,7 +41,7 @@ export default class DynamicDropdownExample extends PureComponent {
 
     return (
       <Dropdown
-        className={classnames(
+        className={clsx(
           theme['Story-padding'],
           theme.Story_Menu,
         )}

--- a/stories/core/ExampleComponents/FreeDrawExample.js
+++ b/stories/core/ExampleComponents/FreeDrawExample.js
@@ -1,7 +1,7 @@
 import React, { PureComponent, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import autobind from 'autobind-decorator'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import themed from '@rentpath/react-themed'
 import { FreeDrawLayer, Button } from 'react-ui-core/src'
 
@@ -64,7 +64,7 @@ export default class FreeDrawExample extends PureComponent {
       <Fragment>
         <Button
           onClick={this.handleClick}
-          className={classnames(
+          className={clsx(
             theme.FreeDrawButton,
             theme[`FreeDrawButton-${enabled}`],
           )}

--- a/stories/core/Filters/RadioGroupFilterCard.js
+++ b/stories/core/Filters/RadioGroupFilterCard.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import themed from '@rentpath/react-themed'
-import classnames from 'classnames'
+import clsx from 'clsx'
 import { action } from '@storybook/addon-actions'
 import { RadioGroupFilterCard } from 'react-ui-core/src'
 
@@ -56,7 +56,7 @@ const InlineBedroomFilterCard = <ThemedInlineBedroomFilterCard />
 
 const InlineBathroomFilterCardComponent = ({ theme }) => (
   <RadioGroupFilterCard
-    className={classnames(theme.InlineCard, theme.BathroomFilterCard)}
+    className={clsx(theme.InlineCard, theme.BathroomFilterCard)}
     title="Filter by bathrooms"
     description="View properties with desired number of bathrooms."
     fields={[
@@ -75,7 +75,7 @@ const InlineBathroomFilterCard = <ThemedInlineBathroomFilterCard />
 
 const DesktopBathroomFilterCardComponent = ({ theme }) => (
   <RadioGroupFilterCard
-    className={classnames(theme.SearchFilter, theme.BathroomFilterCard)}
+    className={clsx(theme.SearchFilter, theme.BathroomFilterCard)}
     title=""
     description=""
     fields={[
@@ -96,7 +96,7 @@ const DesktopBathroomFilterCard = <ThemedDesktopBathroomFilterCard />
 
 const DesktopPetFilterCardComponent = ({ theme }) => (
   <RadioGroupFilterCard
-    className={classnames(theme.SearchFilter, theme.PetFilterCard)}
+    className={clsx(theme.SearchFilter, theme.PetFilterCard)}
     title=""
     description=""
     fields={[
@@ -122,7 +122,7 @@ const InlinePetFilterCardComponent = ({ theme }) => (
   <RadioGroupFilterCard
     title="Find pet friendly rentals"
     description="See apartments that are pet friendly and find your pets a lovely home."
-    className={classnames(theme.InlineCard, theme.PetFilterCard)}
+    className={clsx(theme.InlineCard, theme.PetFilterCard)}
     fields={[
       { label: 'Both', value: 'both', checked: true },
     ]}
@@ -142,7 +142,7 @@ const InlineRatingFilterCardComponent = ({ theme }) => (
   <RadioGroupFilterCard
     title="View 4+ stars units in Atlanta"
     description="Filter and only view properties that have a 4+ star rating from other renters."
-    className={classnames(theme.InlineCard, theme.RatingFilterCard)}
+    className={clsx(theme.InlineCard, theme.RatingFilterCard)}
     fields={[
       { label: '4+ stars', value: '4', checked: true },
     ]}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5105,7 +5105,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5, classnames@^2.2.6:
+classnames@^2.2.5:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -5193,6 +5193,11 @@ clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
+
+clsx@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
 
 co@^4.6.0:
   version "4.6.0"


### PR DESCRIPTION
A switch needs to be made to clsx as it's more performant, smaller and supports esm

affects: @rentpath/react-ui-core, @rentpath/react-ui-utils