### PR TITLE
fix: don’t supply our own token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref || github.ref }}
-          token: ${{ secrets.GH_TOKEN }}
 
       - name: get node version
         id: node-version


### PR DESCRIPTION
Use the one GHA provides instead.

Resolves [DX-406](https://rentpath.atlassian.net/browse/DX-406).