### PR TITLE
chore(clsx): change peerDep version to (hopefully) force publish

### DIFF
--- a/packages/react-ui-core/package.json
+++ b/packages/react-ui-core/package.json
@@ -53,7 +53,7 @@
   },
   "peerDependencies": {
     "@rentpath/react-themed": "^4.1.0",
-    "clsx": "*",
+    "clsx": "1.x",
     "date-fns": "^2.0.0",
     "lodash": "^4.17.10",
     "prop-types": "15.7.2",

--- a/packages/react-ui-utils/package.json
+++ b/packages/react-ui-utils/package.json
@@ -35,6 +35,6 @@
     ]
   },
   "peerDependencies": {
-    "clsx": "*"
+    "clsx": "1.x"
   }
 }


### PR DESCRIPTION
affects: @rentpath/react-ui-core, @rentpath/react-ui-utils