### PR TITLE
AG-6453: add aria-label to carousel nav buttons

### DIFF
--- a/packages/react-ui-core/src/Carousel/CarouselNavigation.js
+++ b/packages/react-ui-core/src/Carousel/CarouselNavigation.js
@@ -45,6 +45,7 @@ export default class CarouselNavigation extends PureComponent {
         )}
         role="button"
         tabIndex={0}
+        aria-label={`${direction} image`}
         {...rest}
       >
         {children}

--- a/packages/react-ui-core/src/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
+++ b/packages/react-ui-core/src/Carousel/__tests__/__snapshots__/Carousel-test.js.snap
@@ -117,6 +117,7 @@ exports[`Carousel navigation renders navigation buttons based on custom node 1`]
             $$typeof={Symbol(react.element)}
             _owner={null}
             _store={Object {}}
+            aria-label="previous image"
             className=""
             data-tag_item="left_arrow"
             data-tid="carousel-navigation-previous"
@@ -137,6 +138,7 @@ exports[`Carousel navigation renders navigation buttons based on custom node 1`]
             $$typeof={Symbol(react.element)}
             _owner={null}
             _store={Object {}}
+            aria-label="next image"
             className=""
             data-tag_item="right_arrow"
             data-tid="carousel-navigation-next"
@@ -253,6 +255,7 @@ exports[`Carousel navigation renders navigation buttons based on object 1`] = `
       >
         <span>
           <button
+            aria-label="previous image"
             className=""
             data-tag_item="left_arrow"
             data-tid="carousel-navigation-previous"
@@ -264,6 +267,7 @@ exports[`Carousel navigation renders navigation buttons based on object 1`] = `
             Previous
           </button>
           <button
+            aria-label="next image"
             className=""
             data-tag_item="right_arrow"
             data-tid="carousel-navigation-next"

--- a/packages/react-ui-core/src/Carousel/__tests__/__snapshots__/CarouselNavigation-test.js.snap
+++ b/packages/react-ui-core/src/Carousel/__tests__/__snapshots__/CarouselNavigation-test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Carousel Navigation renders passed children 1`] = `
 <button
+  aria-label="next image"
   className="CarouselNavigation-next"
   data-tag_item="right_arrow"
   data-tid="carousel-navigation-next"


### PR DESCRIPTION
[AG-6453](https://rentpath.atlassian.net/browse/AG-6453)

Adds accessible text to the previous and next buttons on the image carousel, which currently appear blank to assistive technologies.

- ag.js: https://github.com/rentpath/ag.js/pull/11007
