### PR TITLE
Fix overlay lock class toggle

### DIFF
--- a/packages/react-ui-core/src/Modal/Modal.js
+++ b/packages/react-ui-core/src/Modal/Modal.js
@@ -44,7 +44,7 @@ export default class Modal extends PureComponent {
   }
 
   componentDidMount() {
-    if (this.props.lockBodyScrolling) {
+    if (this.props.lockBodyScrolling && this.props.isOpen) {
       this.toggleBodyClass(true)
     }
   }


### PR DESCRIPTION
[AG-6453](https://rentpath.atlassian.net/browse/AG-6453)

This issue was initially worked around using [this hack](https://github.com/rentpath/ag.js/commit/7e6d4129e2475f169604c48ecc162b61d7ad9028#diff-7a71980a17753e6ba7a50c77b526948c5aeba674ac8ea1dfb6833ce1ae250e48R43) but now that react-themed is being removed from the component it will need to be addressed here.